### PR TITLE
Add support for alias

### DIFF
--- a/graphql-cli/src/main/java/io/ballerina/graphql/generator/ballerina/TypesGenerator.java
+++ b/graphql-cli/src/main/java/io/ballerina/graphql/generator/ballerina/TypesGenerator.java
@@ -76,6 +76,7 @@ import static io.ballerina.graphql.generator.CodeGeneratorConstants.NEW_LINE;
 import static io.ballerina.graphql.generator.CodeGeneratorConstants.QUERY;
 import static io.ballerina.graphql.generator.CodeGeneratorConstants.RESPONSE;
 import static io.ballerina.graphql.generator.CodeGeneratorConstants.WHITESPACE;
+import static io.ballerina.graphql.generator.CodeGeneratorUtils.escapeIdentifier;
 
 /**
  * This class is used to generate ballerina types file according to given SDL and query files.
@@ -165,6 +166,10 @@ public class TypesGenerator {
                 for (ExtendedFieldDefinition extendedFieldDefinition: definition.getExtendedFieldDefinitions()) {
                     String fieldName = extendedFieldDefinition.getName(); // countries
                     String selectionType = queryFieldsMap.get(fieldName).getName(); // Country
+                    String recordFieldName = fieldName;
+                    if (extendedFieldDefinition.getAlias() != null) {
+                        recordFieldName = extendedFieldDefinition.getAlias();
+                    }
                     Map<String, FieldType> fieldsOfSelectionType =
                             SpecReader.getObjectTypeFieldsMap(schema, selectionType);
                     List<Node> inlineRecordFieldList = new ArrayList<>();
@@ -194,7 +199,7 @@ public class TypesGenerator {
 
                     RecordFieldNode queryRecordFieldNode = createRecordFieldNode(null, null,
                             createIdentifierToken(typeDescriptorNode + queryFieldsMap.get(fieldName).getTokens()),
-                            createIdentifierToken(fieldName),
+                            createIdentifierToken(escapeIdentifier(recordFieldName)),
                             null,
                             createToken(SEMICOLON_TOKEN));
                     queryRecordFieldList.add(queryRecordFieldNode);


### PR DESCRIPTION
## Purpose
> Add support for alias

Resolves https://github.com/ballerina-platform/graphql-tools/issues/22

## Goals
> Add support for alias

An example query which uses alias
```
query ExampleQuery2($code1: ID!, $code2: ID!, $code3: ID!) {
  lk: country(code: $code1) {
     code
     name
  }
  au: country(code: $code2) {
     code
     native
  }
  continent(code: $code3) {
    code
    name
  }
}
```

will generate the following record
```
type ExampleQuery2Response record {|
    map<json?> __extensions?;
    record {|
        string code;
        string name;
    |}? lk;
    record {|
        string code;
        string native;
    |}? au;
    record {|
        string code;
        string name;
    |}? continent;
|};
```

## Approach
> 
- If the alias is present, replace the record field name with this value
- Excape Ballerina keywords in alias

## Release note
> Add support for alias

## Automation tests
 - Unit tests 
   > None
 - Integration tests
   > Done

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> 
Ballerina Version: 2201.0.1
Operating System: Ubuntu 20.04
Java SDK: 11