### PR TITLE
Add data binding logic

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,6 +87,9 @@ allprojects {
 
 subprojects {
     apply plugin: 'java'
+    configurations {
+        ballerinaStdLibs
+    }
 }
 
 task codeCoverageReport(type: JacocoReport) {

--- a/graphql-cli/build.gradle
+++ b/graphql-cli/build.gradle
@@ -18,6 +18,10 @@
 apply plugin: "com.github.johnrengelman.shadow"
 apply plugin: "jacoco"
 
+configurations {
+    balTools
+}
+
 dependencies {
     implementation "org.ballerinalang:ballerina-lang:${ballerinaLangVersion}"
     implementation "org.ballerinalang:ballerina-parser:${ballerinaLangVersion}"
@@ -34,6 +38,52 @@ dependencies {
     shadow "com.graphql-java:graphql-java:${graphqlJavaVersion}" // NEW
     shadow "com.google.guava:guava:${googleGuavaVersion}" // NEW
     shadow "org.json:json:${orgJsonVersion}" // NEW
+
+    balTools ("org.ballerinalang:jballerina-tools:${ballerinaLangVersion}") {
+        transitive = false
+    }
+}
+
+def bDistribution = file("$project.buildDir/extracted-distribution/jballerina-tools-${ballerinaLangVersion}")
+task jBallerinaPack {
+    doLast {
+        configurations.balTools.resolvedConfiguration.resolvedArtifacts.each { artifact ->
+            copy {
+                from project.zipTree(artifact.getFile())
+                into new File(project.buildDir, "extracted-distribution/")
+            }
+        }
+    }
+    outputs.dir bDistribution
+}
+
+task unpackStdLibs() {
+    dependsOn(jBallerinaPack)
+    doLast {
+        configurations.ballerinaStdLibs.resolvedConfiguration.resolvedArtifacts.each { artifact ->
+            copy {
+                from project.zipTree(artifact.getFile())
+                into new File("${project.buildDir}/extracted-distribution/" + artifact.name + "-zip")
+            }
+        }
+    }
+}
+
+task copyStdlibs(type: Copy) {
+    dependsOn(unpackStdLibs)
+    def ballerinaDist = "$project.buildDir/extracted-distribution/jballerina-tools-${ballerinaLangVersion}"
+    into ballerinaDist
+
+    /* Standard Libraries */
+    configurations.ballerinaStdLibs.resolvedConfiguration.resolvedArtifacts.each { artifact ->
+        def artifactExtractedPath = "${project.buildDir}/extracted-distribution/" + artifact.name + "-zip"
+        into("repo/bala") {
+            from "${artifactExtractedPath}/bala/"
+        }
+        into("repo/cache") {
+            from "${artifactExtractedPath}/cache"
+        }
+    }
 }
 
 shadowJar {
@@ -43,6 +93,11 @@ shadowJar {
 build.dependsOn(shadowJar)
 
 test {
+    dependsOn {
+        copyStdlibs
+    }
+    systemProperty "ballerina.home", bDistribution
+
     useTestNG() {
         suites "src/test/resources/testng.xml"
     }

--- a/graphql-cli/src/main/java/io/ballerina/graphql/generator/CodeGenerator.java
+++ b/graphql-cli/src/main/java/io/ballerina/graphql/generator/CodeGenerator.java
@@ -153,12 +153,9 @@ public class CodeGenerator {
      */
     private void generateUtils(String projectName, AuthConfig authConfig, List<SrcFilePojo> sourceFiles)
             throws UtilsGenerationException {
-        // Generate utils.bal if the auth configuration is API key config
-        if (authConfig.isApiKeysConfig()) {
-            String utilSrc = UtilsGenerator.getInstance().generateSrc();
-            sourceFiles.add(new SrcFilePojo(SrcFilePojo.GenFileType.GEN_SRC, projectName,
-                    UTILS_FILE_NAME, utilSrc));
-        }
+        String utilSrc = UtilsGenerator.getInstance().generateSrc(authConfig);
+        sourceFiles.add(new SrcFilePojo(SrcFilePojo.GenFileType.GEN_SRC, projectName,
+                UTILS_FILE_NAME, utilSrc));
     }
 
     /**

--- a/graphql-cli/src/main/java/io/ballerina/graphql/generator/CodeGeneratorConstants.java
+++ b/graphql-cli/src/main/java/io/ballerina/graphql/generator/CodeGeneratorConstants.java
@@ -54,6 +54,7 @@ public class CodeGeneratorConstants {
     public static final String SELF = "self";
     public static final String CLIENT_EP = "clientEp";
     public static final String QUERY_VAR_NAME = "query";
+    public static final String GRAPHQL_RESPONSE_VAR_NAME = "graphqlResponse";
     public static final String CLONE_READ_ONLY = "cloneReadOnly";
 
     public static final String FRAGMENT = "Fragment";
@@ -65,6 +66,10 @@ public class CodeGeneratorConstants {
     public static final String HTTP_CLIENT_CONFIG_PARAM_NAME = "clientConfig";
     public static final String SERVICE_URL_TYPE_NAME = "string";
     public static final String SERVICE_URL_PARAM_NAME = "serviceUrl";
+    public static final String GRAPHQL_RESPONSE_TYPE_NAME = "json";
+    public static final String GRAPHQL_RESPONSE_PARAM_NAME = "graphqlResponse";
+    public static final String TARGET_TYPE_PARAM_TYPE_NAME = "typedesc<graphql:DataResponse>";
+    public static final String TARGET_TYPE_PARAM_NAME = "targetType";
     public static final String GRAPHQL_CLIENT_TYPE_NAME = "graphql:Client";
     public static final String GRAPHQL_CLIENT_VAR_NAME = "clientEp";
     public static final String GRAPHQL_VARIABLES_TYPE_NAME = "map<anydata>";

--- a/graphql-cli/src/main/java/io/ballerina/graphql/generator/CodeGeneratorUtils.java
+++ b/graphql-cli/src/main/java/io/ballerina/graphql/generator/CodeGeneratorUtils.java
@@ -196,22 +196,9 @@ public class CodeGeneratorUtils {
      */
     public static String getRemoteFunctionBodyReturnTypeName(String operationName) {
         return "<" + operationName.substring(0, 1).toUpperCase() +
-                operationName.substring(1) + "Response> check self.graphqlClient->" +
-                "execute(" + operationName.substring(0, 1).toUpperCase() +
-                operationName.substring(1) + "Response, query, variables)";
-    }
-
-    /**
-     * Gets the remote function body return type name with Http headers.
-     *
-     * @param operationName    the name of the operation
-     * @return                 the remote function return type name
-     */
-    public static String getRemoteFunctionBodyReturnTypeNameWithHeaders(String operationName) {
-        return "<" + operationName.substring(0, 1).toUpperCase() +
-                operationName.substring(1) + "Response> check self.graphqlClient->" +
-                "execute(" + operationName.substring(0, 1).toUpperCase() +
-                operationName.substring(1) + "Response, query, variables, httpHeaders)";
+                operationName.substring(1) + "Response> check " +
+                "performDataBinding(graphqlResponse, " + operationName.substring(0, 1).toUpperCase() +
+                operationName.substring(1) + "Response)";
     }
 
     public static MetadataNode getMetadataNode(String comment) {

--- a/graphql-cli/src/main/java/io/ballerina/graphql/generator/ballerina/FunctionSignatureGenerator.java
+++ b/graphql-cli/src/main/java/io/ballerina/graphql/generator/ballerina/FunctionSignatureGenerator.java
@@ -215,44 +215,6 @@ public class FunctionSignatureGenerator {
         return apiKeyConfigNode;
     }
 
-//    /**
-//     * Generates the client class remote function parameters.
-//     *
-//     * @param variableDefinitionsMap    the variable definition map from the query definition
-//     * @return                          the list of nodes which represent remote function parameters
-//     */
-//    private List<Node> generateRemoteFunctionParams(Map<String, String> variableDefinitionsMap) {
-//        List<Node> parameters = new ArrayList<>();
-//        List<Node> requiredParameters = new ArrayList<>();
-//        List<Node> optionalParameters = new ArrayList<>();
-//
-//        for (String variableName :variableDefinitionsMap.keySet()) {
-//            if (variableDefinitionsMap.get(variableName).contains(QUESTION_MARK)) {
-//                BuiltinSimpleNameReferenceNode optionalFieldTypeName = createBuiltinSimpleNameReferenceNode(null,
-//                        createIdentifierToken(variableDefinitionsMap.get(variableName)));
-//                IdentifierToken optionalFieldParamName = createIdentifierToken(variableName);
-//                IdentifierToken equalToken = createIdentifierToken(CodeGeneratorConstants.EQUAL);
-//                BasicLiteralNode nullableExpression =
-//                        createBasicLiteralNode(null, createIdentifierToken(NULLABLE_EXPRESSION));
-//                DefaultableParameterNode optionalFieldNode = createDefaultableParameterNode(createEmptyNodeList(),
-//                        optionalFieldTypeName, optionalFieldParamName, equalToken, nullableExpression);
-//                optionalParameters.add(optionalFieldNode);
-//                optionalParameters.add(createToken(COMMA_TOKEN));
-//            } else {
-//                BuiltinSimpleNameReferenceNode requiredFieldTypeName = createBuiltinSimpleNameReferenceNode(null,
-//                        createIdentifierToken(variableDefinitionsMap.get(variableName)));
-//                IdentifierToken requiredFieldParamName = createIdentifierToken(variableName);
-//                RequiredParameterNode requiredFieldNode = createRequiredParameterNode(createEmptyNodeList(),
-//                        requiredFieldTypeName, requiredFieldParamName);
-//                requiredParameters.add(requiredFieldNode);
-//                requiredParameters.add(createToken(COMMA_TOKEN));
-//            }
-//        }
-//        parameters.addAll(requiredParameters);
-//        parameters.addAll(optionalParameters);
-//        return parameters;
-//    }
-
     /**
      * Generates the client class remote function parameters.
      *

--- a/graphql-cli/src/test/java/io/ballerina/graphql/generator/ballerina/FunctionBodyGeneratorTest.java
+++ b/graphql-cli/src/test/java/io/ballerina/graphql/generator/ballerina/FunctionBodyGeneratorTest.java
@@ -181,24 +181,26 @@ public class FunctionBodyGeneratorTest extends GraphqlTest {
     public Object[][] dataProviderForRemoteFunctionBody() {
         return new Object[][]{
                 {"graphql.config.yaml", "{stringquery=string`query country($code:ID!) {country(code:$code) " +
-                        "{capital name}}`;map<anydata>variables={\"code\":code};return<CountryResponse> " +
-                        "check self.graphqlClient->execute(CountryResponse, query, variables);}"},
+                        "{capital name}}`;map<anydata>variables={\"code\":code};" +
+                        "jsongraphqlResponse=checkself.graphqlClient->executeWithType(query,variables);" +
+                        "return<CountryResponse> check performDataBinding(graphqlResponse, CountryResponse);}"},
                 {"graphql-config-with-auth-apikeys-config.yaml", "{stringquery=string`query country($code:ID!) " +
                         "{country(code:$code) {capital name}}`;map<anydata>variables={\"code\":code};" +
                         "map<any>headerValues={\"Header1\":self.apiKeysConfig.header1,\"Header2\":" +
                         "self.apiKeysConfig.header2};map<string|string[]>httpHeaders=getMapForHeaders(headerValues);" +
-                        "return<CountryResponse> check self.graphqlClient->execute(CountryResponse, query, " +
-                        "variables, httpHeaders);}"},
+                        "jsongraphqlResponse=checkself.graphqlClient->executeWithType(query,variables,httpHeaders);" +
+                        "return<CountryResponse> check performDataBinding(graphqlResponse, CountryResponse);}"},
                 {"graphql-config-with-auth-client-config.yaml", "{stringquery=string`query country($code:ID!) " +
                         "{country(code:$code) {capital name}}`;map<anydata>variables={\"code\":code};" +
-                        "return<CountryResponse> check self.graphqlClient->execute(CountryResponse, query, " +
-                        "variables);}"},
+                        "jsongraphqlResponse=checkself.graphqlClient->executeWithType(query,variables);" +
+                        "return<CountryResponse> check performDataBinding(graphqlResponse, CountryResponse);}"},
                 {"graphql-config-with-auth-apikeys-and-client-config.yaml", "{stringquery=string`query " +
-                        "country($code:ID!) {country(code:$code) {capital name}}`;map<anydata>variables=" +
-                        "{\"code\":code};map<any>headerValues={\"Header1\":self.apiKeysConfig.header1," +
-                        "\"Header2\":self.apiKeysConfig.header2};map<string|string[]>httpHeaders=" +
-                        "getMapForHeaders(headerValues);return<CountryResponse> check self.graphqlClient->" +
-                        "execute(CountryResponse, query, variables, httpHeaders);}"}
+                        "country($code:ID!) {country(code:$code) {capital name}}`;" +
+                        "map<anydata>variables={\"code\":code};map<any>headerValues={\"Header1\":" +
+                        "self.apiKeysConfig.header1,\"Header2\":self.apiKeysConfig.header2};" +
+                        "map<string|string[]>httpHeaders=getMapForHeaders(headerValues);" +
+                        "jsongraphqlResponse=checkself.graphqlClient->executeWithType(query,variables,httpHeaders);" +
+                        "return<CountryResponse> check performDataBinding(graphqlResponse, CountryResponse);}"}
         };
     }
 
@@ -214,8 +216,9 @@ public class FunctionBodyGeneratorTest extends GraphqlTest {
                         "map<anydata>variables={\"argument9\":argument9,\"argument5\":argument5," +
                         "\"argument6\":argument6,\"argument7\":argument7,\"argument8\":argument8," +
                         "\"argument1\":argument1,\"argument2\":argument2,\"argument3\":argument3," +
-                        "\"argument4\":argument4};return<Operation1Response> check self.graphqlClient->" +
-                        "execute(Operation1Response, query, variables);}"}
+                        "\"argument4\":argument4};jsongraphqlResponse=checkself.graphqlClient->" +
+                        "executeWithType(query,variables);return<Operation1Response> " +
+                        "check performDataBinding(graphqlResponse, Operation1Response);}"}
         };
     }
 
@@ -225,9 +228,10 @@ public class FunctionBodyGeneratorTest extends GraphqlTest {
                 {"graphql-config-to-test-arguments.yaml", "{stringquery=string`query operation2(" +
                         "$argument1:CustomInput,$argument2:[CustomInput],$argument3:[CustomInput!]) " +
                         "{operation2(argument1:$argument1,argument2:$argument2,argument3:$argument3) " +
-                        "{field1 field2}}`;map<anydata>variables={\"argument1\":argument1,\"argument2\":argument2," +
-                        "\"argument3\":argument3};return<Operation2Response> check self.graphqlClient->" +
-                        "execute(Operation2Response, query, variables);}"}
+                        "{field1 field2}}`;map<anydata>variables={\"argument1\":argument1," +
+                        "\"argument2\":argument2,\"argument3\":argument3};jsongraphqlResponse=" +
+                        "checkself.graphqlClient->executeWithType(query,variables);" +
+                        "return<Operation2Response> check performDataBinding(graphqlResponse, Operation2Response);}"}
         };
     }
 
@@ -237,8 +241,9 @@ public class FunctionBodyGeneratorTest extends GraphqlTest {
                 {"graphql-config-to-test-arguments.yaml", "{stringquery=string`query operation3(" +
                         "$argument1:CustomInput!,$argument2:CustomInput) {operation3(argument1:$argument1," +
                         "argument2:$argument2) {field1 field2}}`;map<anydata>variables={\"argument1\":argument1," +
-                        "\"argument2\":argument2};return<Operation3Response> check self.graphqlClient->" +
-                        "execute(Operation3Response, query, variables);}"}
+                        "\"argument2\":argument2};jsongraphqlResponse=checkself.graphqlClient->" +
+                        "executeWithType(query,variables);return<Operation3Response> " +
+                        "check performDataBinding(graphqlResponse, Operation3Response);}"}
         };
     }
 }

--- a/graphql-cli/src/test/java/io/ballerina/graphql/generator/ballerina/UtilsGeneratorTest.java
+++ b/graphql-cli/src/test/java/io/ballerina/graphql/generator/ballerina/UtilsGeneratorTest.java
@@ -1,28 +1,80 @@
 package io.ballerina.graphql.generator.ballerina;
 
+import io.ballerina.graphql.cmd.GraphqlProject;
+import io.ballerina.graphql.cmd.pojo.Extension;
 import io.ballerina.graphql.common.GraphqlTest;
+import io.ballerina.graphql.common.TestUtils;
+import io.ballerina.graphql.exception.CmdException;
+import io.ballerina.graphql.exception.ParseException;
 import io.ballerina.graphql.exception.UtilsGenerationException;
+import io.ballerina.graphql.exception.ValidationException;
+import io.ballerina.graphql.generator.model.AuthConfig;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 
 /**
  * This class is used to test the functionality of the GraphQL utils code generator.
  */
 public class UtilsGeneratorTest extends GraphqlTest {
 
-    @Test(description = "Test the functionality of the GraphQL utils code generator")
-    public void testGenerateSrc() throws IOException {
+    @Test(description = "Test the functionality of the GraphQL utils code generator with API keys config")
+    public void testGenerateSrcWithApiKeysConfig()
+            throws ValidationException, CmdException, IOException, ParseException {
         try {
-            String generatedUtilsContent = UtilsGenerator.getInstance().generateSrc()
+            List<GraphqlProject> projects = TestUtils.getValidatedMockProjects(
+                    this.resourceDir.resolve(Paths.get("specs",
+                            "graphql-config-with-auth-apikeys-config.yaml")).toString(),
+                    this.tmpDir);
+
+            Extension extensions = projects.get(0).getExtensions();
+
+            AuthConfig authConfig = new AuthConfig();
+            AuthConfigGenerator.getInstance().populateAuthConfigTypes(extensions, authConfig);
+            AuthConfigGenerator.getInstance().populateApiHeaders(extensions, authConfig);
+
+            String generatedUtilsContent = UtilsGenerator.getInstance().generateSrc(authConfig)
                     .trim().replaceAll("\\s+", "")
-                    .replaceAll(System.lineSeparator(), "");;
+                    .replaceAll(System.lineSeparator(), "");
 
             Path expectedUtilsFile =
-                    resourceDir.resolve(Paths.get("expectedGenCode", "utils.bal"));
+                    resourceDir.resolve(Paths.get("expectedGenCode", "client", "apiKeysConfig",
+                            "utils.bal"));
+            String expectedUtilsContent = readContent(expectedUtilsFile);
+
+            Assert.assertEquals(expectedUtilsContent, generatedUtilsContent);
+
+        } catch (UtilsGenerationException e) {
+            Assert.fail("Error while generating the utils code. " + e.getMessage());
+        }
+    }
+
+    @Test(description = "Test the functionality of the GraphQL utils code generator with client config")
+    public void testGenerateSrcWithClientConfig()
+            throws ValidationException, CmdException, IOException, ParseException {
+        try {
+            List<GraphqlProject> projects = TestUtils.getValidatedMockProjects(
+                    this.resourceDir.resolve(Paths.get("specs",
+                            "graphql-config-with-auth-client-config.yaml")).toString(),
+                    this.tmpDir);
+
+            Extension extensions = projects.get(0).getExtensions();
+
+            AuthConfig authConfig = new AuthConfig();
+            AuthConfigGenerator.getInstance().populateAuthConfigTypes(extensions, authConfig);
+            AuthConfigGenerator.getInstance().populateApiHeaders(extensions, authConfig);
+
+            String generatedUtilsContent = UtilsGenerator.getInstance().generateSrc(authConfig)
+                    .trim().replaceAll("\\s+", "")
+                    .replaceAll(System.lineSeparator(), "");
+
+            Path expectedUtilsFile =
+                    resourceDir.resolve(Paths.get("expectedGenCode", "client", "clientConfig",
+                            "utils.bal"));
             String expectedUtilsContent = readContent(expectedUtilsFile);
 
             Assert.assertEquals(expectedUtilsContent, generatedUtilsContent);

--- a/graphql-cli/src/test/java/io/ballerina/graphql/generator/graphql/components/ExtendedOperationDefinitionTest.java
+++ b/graphql-cli/src/test/java/io/ballerina/graphql/generator/graphql/components/ExtendedOperationDefinitionTest.java
@@ -190,7 +190,6 @@ public class ExtendedOperationDefinitionTest extends GraphqlTest {
 
         for (ExtendedFieldDefinition extendedFieldDefinition: generatedExtendedFieldDefinitions) {
             String fieldName = extendedFieldDefinition.getName();
-            log.info(fieldName);
         }
     }
 

--- a/graphql-cli/src/test/resources/expectedGenCode/client/apiKeysConfig/country_queries_client.bal
+++ b/graphql-cli/src/test/resources/expectedGenCode/client/apiKeysConfig/country_queries_client.bal
@@ -20,27 +20,31 @@ public isolated client class CountryqueriesClient {
         map<anydata> variables = {"code": code};
         map<any> headerValues = {"Header1": self.apiKeysConfig.header1, "Header2": self.apiKeysConfig.header2};
         map<string|string[]> httpHeaders = getMapForHeaders(headerValues);
-        return <CountryResponse> check self.graphqlClient->execute(CountryResponse, query, variables, httpHeaders);
+        json graphqlResponse = check self.graphqlClient->executeWithType(query, variables, httpHeaders);
+        return <CountryResponse> check performDataBinding(graphqlResponse, CountryResponse);
     }
     remote isolated function countries(CountryFilterInput? filter = ()) returns CountriesResponse|graphql:Error {
         string query = string `query countries($filter:CountryFilterInput) {countries(filter:$filter) {name continent {countries {name}}}}`;
         map<anydata> variables = {"filter": filter};
         map<any> headerValues = {"Header1": self.apiKeysConfig.header1, "Header2": self.apiKeysConfig.header2};
         map<string|string[]> httpHeaders = getMapForHeaders(headerValues);
-        return <CountriesResponse> check self.graphqlClient->execute(CountriesResponse, query, variables, httpHeaders);
+        json graphqlResponse = check self.graphqlClient->executeWithType(query, variables, httpHeaders);
+        return <CountriesResponse> check performDataBinding(graphqlResponse, CountriesResponse);
     }
     remote isolated function combinedQuery(string code, CountryFilterInput? filter = ()) returns CombinedQueryResponse|graphql:Error {
         string query = string `query combinedQuery($code:ID!,$filter:CountryFilterInput) {country(code:$code) {name} countries(filter:$filter) {name continent {countries {continent {name}}}}}`;
         map<anydata> variables = {"filter": filter, "code": code};
         map<any> headerValues = {"Header1": self.apiKeysConfig.header1, "Header2": self.apiKeysConfig.header2};
         map<string|string[]> httpHeaders = getMapForHeaders(headerValues);
-        return <CombinedQueryResponse> check self.graphqlClient->execute(CombinedQueryResponse, query, variables, httpHeaders);
+        json graphqlResponse = check self.graphqlClient->executeWithType(query, variables, httpHeaders);
+        return <CombinedQueryResponse> check performDataBinding(graphqlResponse, CombinedQueryResponse);
     }
     remote isolated function neighbouringCountries() returns NeighbouringCountriesResponse|graphql:Error {
         string query = string `query neighbouringCountries {countries(filter:{code:{eq:"LK"}}) {name continent {countries {name}}}}`;
         map<anydata> variables = {};
         map<any> headerValues = {"Header1": self.apiKeysConfig.header1, "Header2": self.apiKeysConfig.header2};
         map<string|string[]> httpHeaders = getMapForHeaders(headerValues);
-        return <NeighbouringCountriesResponse> check self.graphqlClient->execute(NeighbouringCountriesResponse, query, variables, httpHeaders);
+        json graphqlResponse = check self.graphqlClient->executeWithType(query, variables, httpHeaders);
+        return <NeighbouringCountriesResponse> check performDataBinding(graphqlResponse, NeighbouringCountriesResponse);
     }
 }

--- a/graphql-cli/src/test/resources/expectedGenCode/client/apiKeysConfig/utils.bal
+++ b/graphql-cli/src/test/resources/expectedGenCode/client/apiKeysConfig/utils.bal
@@ -12,7 +12,7 @@ isolated function getMapForHeaders(map<any> headerParam) returns map<string|stri
         } else if value is int[] {
             string[] stringArray = [];
             foreach int intValue in value {
-               stringArray.push(intValue.toString());
+                stringArray.push(intValue.toString());
             }
             headerMap[key] = stringArray;
         } else if value is SimpleBasicType {
@@ -23,12 +23,12 @@ isolated function getMapForHeaders(map<any> headerParam) returns map<string|stri
 }
 
 isolated function performDataBinding(json graphqlResponse, typedesc<graphql:DataResponse> targetType)
-                                     returns graphql:DataResponse|graphql:ClientError {
+                                    returns graphql:DataResponse|graphql:ClientError {
     do {
-        map<json> responseMap = <map<json>> graphqlResponse;
+        map<json> responseMap = <map<json>>graphqlResponse;
         json responseData = responseMap.get("data");
         if (responseMap.hasKey("extensions")) {
-            responseData = check responseData.mergeJson({ "__extensions" : responseMap.get("extensions") });
+            responseData = check responseData.mergeJson({"__extensions": responseMap.get("extensions")});
         }
         graphql:DataResponse response = check responseData.cloneWithType(targetType);
         return response;

--- a/graphql-cli/src/test/resources/expectedGenCode/client/clientConfig/country_queries_client.bal
+++ b/graphql-cli/src/test/resources/expectedGenCode/client/clientConfig/country_queries_client.bal
@@ -44,21 +44,25 @@ public isolated client class CountryqueriesClient {
     remote isolated function country(string code) returns CountryResponse|graphql:Error {
         string query = string `query country($code:ID!) {country(code:$code) {capital name}}`;
         map<anydata> variables = {"code": code};
-        return <CountryResponse> check self.graphqlClient->execute(CountryResponse, query, variables);
+        json graphqlResponse = check self.graphqlClient->executeWithType(query, variables);
+        return <CountryResponse> check performDataBinding(graphqlResponse, CountryResponse);
     }
     remote isolated function countries(CountryFilterInput? filter = ()) returns CountriesResponse|graphql:Error {
         string query = string `query countries($filter:CountryFilterInput) {countries(filter:$filter) {name continent {countries {name}}}}`;
         map<anydata> variables = {"filter": filter};
-        return <CountriesResponse> check self.graphqlClient->execute(CountriesResponse, query, variables);
+        json graphqlResponse = check self.graphqlClient->executeWithType(query, variables);
+        return <CountriesResponse> check performDataBinding(graphqlResponse, CountriesResponse);
     }
     remote isolated function combinedQuery(string code, CountryFilterInput? filter = ()) returns CombinedQueryResponse|graphql:Error {
         string query = string `query combinedQuery($code:ID!,$filter:CountryFilterInput) {country(code:$code) {name} countries(filter:$filter) {name continent {countries {continent {name}}}}}`;
         map<anydata> variables = {"filter": filter, "code": code};
-        return <CombinedQueryResponse> check self.graphqlClient->execute(CombinedQueryResponse, query, variables);
+        json graphqlResponse = check self.graphqlClient->executeWithType(query, variables);
+        return <CombinedQueryResponse> check performDataBinding(graphqlResponse, CombinedQueryResponse);
     }
     remote isolated function neighbouringCountries() returns NeighbouringCountriesResponse|graphql:Error {
         string query = string `query neighbouringCountries {countries(filter:{code:{eq:"LK"}}) {name continent {countries {name}}}}`;
         map<anydata> variables = {};
-        return <NeighbouringCountriesResponse> check self.graphqlClient->execute(NeighbouringCountriesResponse, query, variables);
+        json graphqlResponse = check self.graphqlClient->executeWithType(query, variables);
+        return <NeighbouringCountriesResponse> check performDataBinding(graphqlResponse, NeighbouringCountriesResponse);
     }
 }

--- a/graphql-cli/src/test/resources/expectedGenCode/client/clientConfig/utils.bal
+++ b/graphql-cli/src/test/resources/expectedGenCode/client/clientConfig/utils.bal
@@ -1,0 +1,15 @@
+
+isolated function performDataBinding(json graphqlResponse, typedesc<graphql:DataResponse> targetType)
+                                    returns graphql:DataResponse|graphql:ClientError {
+    do {
+        map<json> responseMap = <map<json>>graphqlResponse;
+        json responseData = responseMap.get("data");
+        if (responseMap.hasKey("extensions")) {
+            responseData = check responseData.mergeJson({"__extensions": responseMap.get("extensions")});
+        }
+        graphql:DataResponse response = check responseData.cloneWithType(targetType);
+        return response;
+    } on fail var e {
+        return error graphql:ClientError("GraphQL Client Error", e);
+    }
+}

--- a/graphql-cli/src/test/resources/expectedGenCode/country_queries_client.bal
+++ b/graphql-cli/src/test/resources/expectedGenCode/country_queries_client.bal
@@ -11,21 +11,25 @@ public isolated client class CountryqueriesClient {
     remote isolated function country(string code) returns CountryResponse|graphql:Error {
         string query = string `query country($code:ID!) {country(code:$code) {capital name}}`;
         map<anydata> variables = {"code": code};
-        return <CountryResponse> check self.graphqlClient->execute(CountryResponse, query, variables);
+        json graphqlResponse = check self.graphqlClient->executeWithType(query, variables);
+        return <CountryResponse> check performDataBinding(graphqlResponse, CountryResponse);
     }
     remote isolated function countries(CountryFilterInput? filter = ()) returns CountriesResponse|graphql:Error {
         string query = string `query countries($filter:CountryFilterInput) {countries(filter:$filter) {name continent {countries {name}}}}`;
         map<anydata> variables = {"filter": filter};
-        return <CountriesResponse> check self.graphqlClient->execute(CountriesResponse, query, variables);
+        json graphqlResponse = check self.graphqlClient->executeWithType(query, variables);
+        return <CountriesResponse> check performDataBinding(graphqlResponse, CountriesResponse);
     }
     remote isolated function combinedQuery(string code, CountryFilterInput? filter = ()) returns CombinedQueryResponse|graphql:Error {
         string query = string `query combinedQuery($code:ID!,$filter:CountryFilterInput) {country(code:$code) {name} countries(filter:$filter) {name continent {countries {continent {name}}}}}`;
         map<anydata> variables = {"filter": filter, "code": code};
-        return <CombinedQueryResponse> check self.graphqlClient->execute(CombinedQueryResponse, query, variables);
+        json graphqlResponse = check self.graphqlClient->executeWithType(query, variables);
+        return <CombinedQueryResponse> check performDataBinding(graphqlResponse, CombinedQueryResponse);
     }
     remote isolated function neighbouringCountries() returns NeighbouringCountriesResponse|graphql:Error {
         string query = string `query neighbouringCountries {countries(filter:{code:{eq:"LK"}}) {name continent {countries {name}}}}`;
         map<anydata> variables = {};
-        return <NeighbouringCountriesResponse> check self.graphqlClient->execute(NeighbouringCountriesResponse, query, variables);
+        json graphqlResponse = check self.graphqlClient->executeWithType(query, variables);
+        return <NeighbouringCountriesResponse> check performDataBinding(graphqlResponse, NeighbouringCountriesResponse);
     }
 }

--- a/graphql-cli/src/test/resources/specs/queries/country-queries.graphql
+++ b/graphql-cli/src/test/resources/specs/queries/country-queries.graphql
@@ -5,8 +5,8 @@ query country($code: ID!) {
     }
 }
 
-query countries($filter: CountryFilterInput) { 
-    countries(filter: $filter) {   
+query countries($filter: CountryFilterInput) {
+    countries(filter: $filter) {
         name
         continent {
             countries {
@@ -16,7 +16,7 @@ query countries($filter: CountryFilterInput) {
     }
 }
 
-query combinedQuery($code: ID!, $filter: CountryFilterInput) { 
+query combinedQuery($code: ID!, $filter: CountryFilterInput) {
     country(code: $code) {
         name
     }

--- a/graphql-cli/src/test/resources/testng.xml
+++ b/graphql-cli/src/test/resources/testng.xml
@@ -34,6 +34,7 @@
             <class name="io.ballerina.graphql.generator.ballerina.FunctionBodyGeneratorTest"/>
             <class name="io.ballerina.graphql.generator.ballerina.TypesGeneratorTest"/>
             <class name="io.ballerina.graphql.generator.ballerina.ClientGeneratorTest"/>
+            <class name="io.ballerina.graphql.generator.ballerina.UtilsGeneratorTest"/>
             <class name="io.ballerina.graphql.generator.CodeGeneratorTest"/>
         </classes>
     </test>


### PR DESCRIPTION
## Purpose
> Add data binding logic

It was decided to remove the following response processing logic from the generic GraphQL client after the discussion with the Ballerina team, This PR provides all the necessary changes to move this logic to be handled in the generated client code.  


```
remote isolated function execute(typedesc<record {| json...; |}> returnType, string query, 
                                    map<anydata>? variables = (), map<string|string[]>? headers = ()) 
                                    returns record {| json...; |}|Error {
      http:Request request = new;
      json graphqlPayload = getGraphqlPayload(query, variables);
      request.setPayload(graphqlPayload);

      json|http:ClientError httpResponse = self.clientEp->post("", request, headers = headers);

      do {
         if httpResponse is http:ClientError {
            if (httpResponse is http:ApplicationResponseError) {
               anydata data = check httpResponse.detail().get("body").ensureType(anydata);
               return error ClientError("GraphQL Client Error", body = data);
            }
            return error ClientError("GraphQL Client Error", httpResponse);
         } else {
            map<json> responseMap = <map<json>> httpResponse;

            if (responseMap.hasKey("errors")) {
               GraphQLClientError[] errors = check responseMap.get("errors").cloneWithType(GraphQLClientErrorArray);
               
               if (responseMap.hasKey("data") && !responseMap.hasKey("extensions")) {
                  return error ServerError("GraphQL Server Error", data = responseMap.get("data"), errors = errors);
               } else if (responseMap.hasKey("extensions") && !responseMap.hasKey("data")) {
                  map<json>? extensionsMap = 
                     (responseMap.get("extensions") is ()) ? () : <map<json>> responseMap.get("extensions");
                  return error ServerError("GraphQL Server Error", errors = errors, extensions = extensionsMap);
               } else if (responseMap.hasKey("data") && responseMap.hasKey("extensions")) {
                  map<json>? extensionsMap = 
                     (responseMap.get("extensions") is ()) ? () : <map<json>> responseMap.get("extensions") ;
                  return error ServerError("GraphQL Server Error", data = responseMap.get("data"), errors = errors, 
                     extensions = extensionsMap);
               } else {
                  return error ServerError("GraphQL Server Error", errors = errors);
               }
            } else {
               json responseData = responseMap.get("data");
               if (responseMap.hasKey("extensions")) {
                  responseData = check responseData.mergeJson({ "extensions" : responseMap.get("extensions") });
               }
               record {| json...; |} response = check responseData.cloneWithType(returnType);
               return response;
            }
         }
      } on fail var e {
         return error ClientError("GraphQL Client Error", e);
      }
   }
```

Resolves https://github.com/ballerina-platform/graphql-tools/issues/29

## Goals
> Move the GraphQL response processing logic to the generated client code

## Approach
> 
- Add data binding logic to the utils.bal file template
- Modify function body generator
- Modify utils generator
- Modify function body generator tests
- Add utils generator tests

## Release note
> Add data binding logic

## Automation tests
 - Unit tests 
   > Done
 - Integration tests
   > Done

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> 
Ballerina Version: 2201.0.1
Operating System: Ubuntu 20.04
Java SDK: 11