### PR TITLE
Address generic graphql client changes

### DIFF
--- a/graphql-cli/src/main/java/io/ballerina/graphql/generator/CodeGeneratorConstants.java
+++ b/graphql-cli/src/main/java/io/ballerina/graphql/generator/CodeGeneratorConstants.java
@@ -50,7 +50,7 @@ public class CodeGeneratorConstants {
     public static final String CLIENT = "Client";
     public static final String GRAPHQL_CLIENT = "graphqlClient";
     public static final String INIT = "init";
-    public static final String INIT_RETURN_TYPE = "graphql:Error";
+    public static final String INIT_RETURN_TYPE = "graphql:ClientError";
     public static final String SELF = "self";
     public static final String CLIENT_EP = "clientEp";
     public static final String QUERY_VAR_NAME = "query";

--- a/graphql-cli/src/main/java/io/ballerina/graphql/generator/CodeGeneratorUtils.java
+++ b/graphql-cli/src/main/java/io/ballerina/graphql/generator/CodeGeneratorUtils.java
@@ -185,7 +185,7 @@ public class CodeGeneratorUtils {
      */
     public static String getRemoteFunctionSignatureReturnTypeName(String operationName) {
         return operationName.substring(0, 1).toUpperCase() +
-                operationName.substring(1).concat("Response|graphql:Error");
+                operationName.substring(1).concat("Response|graphql:ClientError");
     }
 
     /**

--- a/graphql-cli/src/main/java/io/ballerina/graphql/generator/ballerina/ClientGenerator.java
+++ b/graphql-cli/src/main/java/io/ballerina/graphql/generator/ballerina/ClientGenerator.java
@@ -151,7 +151,7 @@ public class ClientGenerator {
         ImportDeclarationNode importForHttp = CodeGeneratorUtils.getImportDeclarationNode(
                 CodeGeneratorConstants.BALLERINA, CodeGeneratorConstants.HTTP);
         ImportDeclarationNode importForGraphql = CodeGeneratorUtils.getImportDeclarationNode(
-                CodeGeneratorConstants.BALLERINAX, CodeGeneratorConstants.GRAPHQL);
+                CodeGeneratorConstants.BALLERINA, CodeGeneratorConstants.GRAPHQL);
         imports.add(importForHttp);
         imports.add(importForGraphql);
         return createNodeList(imports);

--- a/graphql-cli/src/main/java/io/ballerina/graphql/generator/ballerina/FunctionBodyGenerator.java
+++ b/graphql-cli/src/main/java/io/ballerina/graphql/generator/ballerina/FunctionBodyGenerator.java
@@ -69,6 +69,7 @@ import static io.ballerina.compiler.syntax.tree.NodeFactory.createFunctionCallEx
 import static io.ballerina.compiler.syntax.tree.NodeFactory.createImplicitNewExpressionNode;
 import static io.ballerina.compiler.syntax.tree.NodeFactory.createMappingConstructorExpressionNode;
 import static io.ballerina.compiler.syntax.tree.NodeFactory.createMethodCallExpressionNode;
+import static io.ballerina.compiler.syntax.tree.NodeFactory.createNamedArgumentNode;
 import static io.ballerina.compiler.syntax.tree.NodeFactory.createParenthesizedArgList;
 import static io.ballerina.compiler.syntax.tree.NodeFactory.createPositionalArgumentNode;
 import static io.ballerina.compiler.syntax.tree.NodeFactory.createRemoteMethodCallActionNode;
@@ -505,7 +506,7 @@ public class FunctionBodyGenerator {
         FieldAccessExpressionNode graphqlClientFieldAccessExpr = createFieldAccessExpressionNode(
                 createSimpleNameReferenceNode(createIdentifierToken("self")), createToken(DOT_TOKEN), fieldName);
 
-        // {@code self.graphqlClient->executeWithType(query, variables, httpHeaders)} declaration
+        // {@code self.graphqlClient->executeWithType(query, variables, headers = httpHeaders)} declaration
         SimpleNameReferenceNode methodName =
                 createSimpleNameReferenceNode(createIdentifierToken("executeWithType"));
         List<Node> arguments = new ArrayList<>();
@@ -513,8 +514,9 @@ public class FunctionBodyGenerator {
                 createPositionalArgumentNode(createSimpleNameReferenceNode(createIdentifierToken("query")));
         FunctionArgumentNode variablesArgument =
                 createPositionalArgumentNode(createSimpleNameReferenceNode(createIdentifierToken("variables")));
-        FunctionArgumentNode httpHeadersArgument =
-                createPositionalArgumentNode(createSimpleNameReferenceNode(createIdentifierToken("httpHeaders")));
+        FunctionArgumentNode httpHeadersArgument = createNamedArgumentNode(
+                createSimpleNameReferenceNode(createIdentifierToken("headers")), createToken(EQUAL_TOKEN),
+                createSimpleNameReferenceNode(createIdentifierToken("httpHeaders")));
         arguments.add(queryArgument);
         arguments.add(createToken(COMMA_TOKEN));
         arguments.add(variablesArgument);

--- a/graphql-cli/src/main/resources/templates/utils.bal
+++ b/graphql-cli/src/main/resources/templates/utils.bal
@@ -22,17 +22,28 @@ isolated function getMapForHeaders(map<any> headerParam) returns map<string|stri
     return headerMap;
 }
 
-isolated function performDataBinding(json graphqlResponse, typedesc<graphql:DataResponse> targetType)
-                                     returns graphql:DataResponse|graphql:ClientError {
+isolated function performDataBinding(json graphqlResponse, typedesc<DataResponse> targetType)
+                                     returns DataResponse|graphql:RequestError {
     do {
         map<json> responseMap = <map<json>> graphqlResponse;
         json responseData = responseMap.get("data");
         if (responseMap.hasKey("extensions")) {
             responseData = check responseData.mergeJson({ "__extensions" : responseMap.get("extensions") });
         }
-        graphql:DataResponse response = check responseData.cloneWithType(targetType);
+        DataResponse response = check responseData.cloneWithType(targetType);
         return response;
     } on fail var e {
-        return error graphql:ClientError("GraphQL Client Error", e);
+        return error graphql:RequestError("GraphQL Client Error", e);
     }
 }
+
+# Represents return types of a GraphQL operation.
+type OperationResponse record {| anydata...; |}|record {| anydata...; |}[]|boolean|string|int|float|();
+
+# Represents the data representation of a GraphQL response for `executeWithType` method.
+#
+# + __extensions - Meta information of the GraphQL API call
+type DataResponse record {|
+   map<json?> __extensions?;
+   OperationResponse ...;
+|};

--- a/graphql-cli/src/test/java/io/ballerina/graphql/generator/ballerina/FunctionBodyGeneratorTest.java
+++ b/graphql-cli/src/test/java/io/ballerina/graphql/generator/ballerina/FunctionBodyGeneratorTest.java
@@ -188,7 +188,8 @@ public class FunctionBodyGeneratorTest extends GraphqlTest {
                         "{country(code:$code) {capital name}}`;map<anydata>variables={\"code\":code};" +
                         "map<any>headerValues={\"Header1\":self.apiKeysConfig.header1,\"Header2\":" +
                         "self.apiKeysConfig.header2};map<string|string[]>httpHeaders=getMapForHeaders(headerValues);" +
-                        "jsongraphqlResponse=checkself.graphqlClient->executeWithType(query,variables,httpHeaders);" +
+                        "jsongraphqlResponse=checkself.graphqlClient->executeWithType(query,variables," +
+                        "headers=httpHeaders);" +
                         "return<CountryResponse> check performDataBinding(graphqlResponse, CountryResponse);}"},
                 {"graphql-config-with-auth-client-config.yaml", "{stringquery=string`query country($code:ID!) " +
                         "{country(code:$code) {capital name}}`;map<anydata>variables={\"code\":code};" +
@@ -199,7 +200,8 @@ public class FunctionBodyGeneratorTest extends GraphqlTest {
                         "map<anydata>variables={\"code\":code};map<any>headerValues={\"Header1\":" +
                         "self.apiKeysConfig.header1,\"Header2\":self.apiKeysConfig.header2};" +
                         "map<string|string[]>httpHeaders=getMapForHeaders(headerValues);" +
-                        "jsongraphqlResponse=checkself.graphqlClient->executeWithType(query,variables,httpHeaders);" +
+                        "jsongraphqlResponse=checkself.graphqlClient->executeWithType(query,variables," +
+                        "headers=httpHeaders);" +
                         "return<CountryResponse> check performDataBinding(graphqlResponse, CountryResponse);}"}
         };
     }

--- a/graphql-cli/src/test/resources/expectedGenCode/client/apiKeysConfig/country_queries_client.bal
+++ b/graphql-cli/src/test/resources/expectedGenCode/client/apiKeysConfig/country_queries_client.bal
@@ -1,5 +1,5 @@
 import ballerina/http;
-import ballerinax/graphql;
+import ballerina/graphql;
 
 public type ApiKeysConfig record {|
     string header1;
@@ -9,42 +9,42 @@ public type ApiKeysConfig record {|
 public isolated client class CountryqueriesClient {
     final graphql:Client graphqlClient;
     final readonly & ApiKeysConfig apiKeysConfig;
-    public isolated function init(ApiKeysConfig apiKeysConfig, string serviceUrl, http:ClientConfiguration clientConfig = {}) returns graphql:Error? {
+    public isolated function init(ApiKeysConfig apiKeysConfig, string serviceUrl, http:ClientConfiguration clientConfig = {}) returns graphql:ClientError? {
         graphql:Client clientEp = check new (serviceUrl, clientConfig);
         self.graphqlClient = clientEp;
         self.apiKeysConfig = apiKeysConfig.cloneReadOnly();
         return;
     }
-    remote isolated function country(string code) returns CountryResponse|graphql:Error {
+    remote isolated function country(string code) returns CountryResponse|graphql:ClientError {
         string query = string `query country($code:ID!) {country(code:$code) {capital name}}`;
         map<anydata> variables = {"code": code};
         map<any> headerValues = {"Header1": self.apiKeysConfig.header1, "Header2": self.apiKeysConfig.header2};
         map<string|string[]> httpHeaders = getMapForHeaders(headerValues);
-        json graphqlResponse = check self.graphqlClient->executeWithType(query, variables, httpHeaders);
+        json graphqlResponse = check self.graphqlClient->executeWithType(query, variables, headers = httpHeaders);
         return <CountryResponse> check performDataBinding(graphqlResponse, CountryResponse);
     }
-    remote isolated function countries(CountryFilterInput? filter = ()) returns CountriesResponse|graphql:Error {
+    remote isolated function countries(CountryFilterInput? filter = ()) returns CountriesResponse|graphql:ClientError {
         string query = string `query countries($filter:CountryFilterInput) {countries(filter:$filter) {name continent {countries {name}}}}`;
         map<anydata> variables = {"filter": filter};
         map<any> headerValues = {"Header1": self.apiKeysConfig.header1, "Header2": self.apiKeysConfig.header2};
         map<string|string[]> httpHeaders = getMapForHeaders(headerValues);
-        json graphqlResponse = check self.graphqlClient->executeWithType(query, variables, httpHeaders);
+        json graphqlResponse = check self.graphqlClient->executeWithType(query, variables, headers = httpHeaders);
         return <CountriesResponse> check performDataBinding(graphqlResponse, CountriesResponse);
     }
-    remote isolated function combinedQuery(string code, CountryFilterInput? filter = ()) returns CombinedQueryResponse|graphql:Error {
+    remote isolated function combinedQuery(string code, CountryFilterInput? filter = ()) returns CombinedQueryResponse|graphql:ClientError {
         string query = string `query combinedQuery($code:ID!,$filter:CountryFilterInput) {country(code:$code) {name} countries(filter:$filter) {name continent {countries {continent {name}}}}}`;
         map<anydata> variables = {"filter": filter, "code": code};
         map<any> headerValues = {"Header1": self.apiKeysConfig.header1, "Header2": self.apiKeysConfig.header2};
         map<string|string[]> httpHeaders = getMapForHeaders(headerValues);
-        json graphqlResponse = check self.graphqlClient->executeWithType(query, variables, httpHeaders);
+        json graphqlResponse = check self.graphqlClient->executeWithType(query, variables, headers = httpHeaders);
         return <CombinedQueryResponse> check performDataBinding(graphqlResponse, CombinedQueryResponse);
     }
-    remote isolated function neighbouringCountries() returns NeighbouringCountriesResponse|graphql:Error {
+    remote isolated function neighbouringCountries() returns NeighbouringCountriesResponse|graphql:ClientError {
         string query = string `query neighbouringCountries {countries(filter:{code:{eq:"LK"}}) {name continent {countries {name}}}}`;
         map<anydata> variables = {};
         map<any> headerValues = {"Header1": self.apiKeysConfig.header1, "Header2": self.apiKeysConfig.header2};
         map<string|string[]> httpHeaders = getMapForHeaders(headerValues);
-        json graphqlResponse = check self.graphqlClient->executeWithType(query, variables, httpHeaders);
+        json graphqlResponse = check self.graphqlClient->executeWithType(query, variables, headers = httpHeaders);
         return <NeighbouringCountriesResponse> check performDataBinding(graphqlResponse, NeighbouringCountriesResponse);
     }
 }

--- a/graphql-cli/src/test/resources/expectedGenCode/client/apiKeysConfig/utils.bal
+++ b/graphql-cli/src/test/resources/expectedGenCode/client/apiKeysConfig/utils.bal
@@ -1,4 +1,13 @@
+import ballerina/graphql;
+
 type SimpleBasicType string|boolean|int|float|decimal;
+
+type OperationResponse record {| anydata...; |}|record {| anydata...; |}[]|boolean|string|int|float|();
+
+type DataResponse record {|
+   map<json?> __extensions?;
+   OperationResponse ...;
+|};
 
 # Generate header map for given header values.
 #
@@ -22,17 +31,17 @@ isolated function getMapForHeaders(map<any> headerParam) returns map<string|stri
     return headerMap;
 }
 
-isolated function performDataBinding(json graphqlResponse, typedesc<graphql:DataResponse> targetType)
-                                    returns graphql:DataResponse|graphql:ClientError {
+isolated function performDataBinding(json graphqlResponse, typedesc<DataResponse> targetType)
+                                    returns DataResponse|graphql:RequestError {
     do {
         map<json> responseMap = <map<json>>graphqlResponse;
         json responseData = responseMap.get("data");
         if (responseMap.hasKey("extensions")) {
             responseData = check responseData.mergeJson({"__extensions": responseMap.get("extensions")});
         }
-        graphql:DataResponse response = check responseData.cloneWithType(targetType);
+        DataResponse response = check responseData.cloneWithType(targetType);
         return response;
     } on fail var e {
-        return error graphql:ClientError("GraphQL Client Error", e);
+        return error graphql:RequestError("GraphQL Client Error", e);
     }
 }

--- a/graphql-cli/src/test/resources/expectedGenCode/client/clientConfig/country_queries_client.bal
+++ b/graphql-cli/src/test/resources/expectedGenCode/client/clientConfig/country_queries_client.bal
@@ -1,5 +1,5 @@
 import ballerina/http;
-import ballerinax/graphql;
+import ballerina/graphql;
 
 public type ClientConfig record {|
     # Configurations related to client authentication
@@ -36,30 +36,30 @@ public type ClientConfig record {|
 
 public isolated client class CountryqueriesClient {
     final graphql:Client graphqlClient;
-    public isolated function init(ClientConfig clientConfig, string serviceUrl) returns graphql:Error? {
+    public isolated function init(ClientConfig clientConfig, string serviceUrl) returns graphql:ClientError? {
         graphql:Client clientEp = check new (serviceUrl, clientConfig);
         self.graphqlClient = clientEp;
         return;
     }
-    remote isolated function country(string code) returns CountryResponse|graphql:Error {
+    remote isolated function country(string code) returns CountryResponse|graphql:ClientError {
         string query = string `query country($code:ID!) {country(code:$code) {capital name}}`;
         map<anydata> variables = {"code": code};
         json graphqlResponse = check self.graphqlClient->executeWithType(query, variables);
         return <CountryResponse> check performDataBinding(graphqlResponse, CountryResponse);
     }
-    remote isolated function countries(CountryFilterInput? filter = ()) returns CountriesResponse|graphql:Error {
+    remote isolated function countries(CountryFilterInput? filter = ()) returns CountriesResponse|graphql:ClientError {
         string query = string `query countries($filter:CountryFilterInput) {countries(filter:$filter) {name continent {countries {name}}}}`;
         map<anydata> variables = {"filter": filter};
         json graphqlResponse = check self.graphqlClient->executeWithType(query, variables);
         return <CountriesResponse> check performDataBinding(graphqlResponse, CountriesResponse);
     }
-    remote isolated function combinedQuery(string code, CountryFilterInput? filter = ()) returns CombinedQueryResponse|graphql:Error {
+    remote isolated function combinedQuery(string code, CountryFilterInput? filter = ()) returns CombinedQueryResponse|graphql:ClientError {
         string query = string `query combinedQuery($code:ID!,$filter:CountryFilterInput) {country(code:$code) {name} countries(filter:$filter) {name continent {countries {continent {name}}}}}`;
         map<anydata> variables = {"filter": filter, "code": code};
         json graphqlResponse = check self.graphqlClient->executeWithType(query, variables);
         return <CombinedQueryResponse> check performDataBinding(graphqlResponse, CombinedQueryResponse);
     }
-    remote isolated function neighbouringCountries() returns NeighbouringCountriesResponse|graphql:Error {
+    remote isolated function neighbouringCountries() returns NeighbouringCountriesResponse|graphql:ClientError {
         string query = string `query neighbouringCountries {countries(filter:{code:{eq:"LK"}}) {name continent {countries {name}}}}`;
         map<anydata> variables = {};
         json graphqlResponse = check self.graphqlClient->executeWithType(query, variables);

--- a/graphql-cli/src/test/resources/expectedGenCode/client/clientConfig/utils.bal
+++ b/graphql-cli/src/test/resources/expectedGenCode/client/clientConfig/utils.bal
@@ -1,15 +1,23 @@
+import ballerina/graphql;
 
-isolated function performDataBinding(json graphqlResponse, typedesc<graphql:DataResponse> targetType)
-                                    returns graphql:DataResponse|graphql:ClientError {
+type OperationResponse record {| anydata...; |}|record {| anydata...; |}[]|boolean|string|int|float|();
+
+type DataResponse record {|
+   map<json?> __extensions?;
+   OperationResponse ...;
+|};
+
+isolated function performDataBinding(json graphqlResponse, typedesc<DataResponse> targetType)
+                                    returns DataResponse|graphql:RequestError {
     do {
         map<json> responseMap = <map<json>>graphqlResponse;
         json responseData = responseMap.get("data");
         if (responseMap.hasKey("extensions")) {
             responseData = check responseData.mergeJson({"__extensions": responseMap.get("extensions")});
         }
-        graphql:DataResponse response = check responseData.cloneWithType(targetType);
+        DataResponse response = check responseData.cloneWithType(targetType);
         return response;
     } on fail var e {
-        return error graphql:ClientError("GraphQL Client Error", e);
+        return error graphql:RequestError("GraphQL Client Error", e);
     }
 }

--- a/graphql-cli/src/test/resources/expectedGenCode/country_queries_client.bal
+++ b/graphql-cli/src/test/resources/expectedGenCode/country_queries_client.bal
@@ -1,32 +1,32 @@
 import ballerina/http;
-import ballerinax/graphql;
+import ballerina/graphql;
 
 public isolated client class CountryqueriesClient {
     final graphql:Client graphqlClient;
-    public isolated function init(string serviceUrl, http:ClientConfiguration clientConfig = {}) returns graphql:Error? {
+    public isolated function init(string serviceUrl, http:ClientConfiguration clientConfig = {}) returns graphql:ClientError? {
         graphql:Client clientEp = check new (serviceUrl, clientConfig);
         self.graphqlClient = clientEp;
         return;
     }
-    remote isolated function country(string code) returns CountryResponse|graphql:Error {
+    remote isolated function country(string code) returns CountryResponse|graphql:ClientError {
         string query = string `query country($code:ID!) {country(code:$code) {capital name}}`;
         map<anydata> variables = {"code": code};
         json graphqlResponse = check self.graphqlClient->executeWithType(query, variables);
         return <CountryResponse> check performDataBinding(graphqlResponse, CountryResponse);
     }
-    remote isolated function countries(CountryFilterInput? filter = ()) returns CountriesResponse|graphql:Error {
+    remote isolated function countries(CountryFilterInput? filter = ()) returns CountriesResponse|graphql:ClientError {
         string query = string `query countries($filter:CountryFilterInput) {countries(filter:$filter) {name continent {countries {name}}}}`;
         map<anydata> variables = {"filter": filter};
         json graphqlResponse = check self.graphqlClient->executeWithType(query, variables);
         return <CountriesResponse> check performDataBinding(graphqlResponse, CountriesResponse);
     }
-    remote isolated function combinedQuery(string code, CountryFilterInput? filter = ()) returns CombinedQueryResponse|graphql:Error {
+    remote isolated function combinedQuery(string code, CountryFilterInput? filter = ()) returns CombinedQueryResponse|graphql:ClientError {
         string query = string `query combinedQuery($code:ID!,$filter:CountryFilterInput) {country(code:$code) {name} countries(filter:$filter) {name continent {countries {continent {name}}}}}`;
         map<anydata> variables = {"filter": filter, "code": code};
         json graphqlResponse = check self.graphqlClient->executeWithType(query, variables);
         return <CombinedQueryResponse> check performDataBinding(graphqlResponse, CombinedQueryResponse);
     }
-    remote isolated function neighbouringCountries() returns NeighbouringCountriesResponse|graphql:Error {
+    remote isolated function neighbouringCountries() returns NeighbouringCountriesResponse|graphql:ClientError {
         string query = string `query neighbouringCountries {countries(filter:{code:{eq:"LK"}}) {name continent {countries {name}}}}`;
         map<anydata> variables = {};
         json graphqlResponse = check self.graphqlClient->executeWithType(query, variables);

--- a/graphql-cli/src/test/resources/expectedGenCode/functionSignature/initFunctionSignature.bal
+++ b/graphql-cli/src/test/resources/expectedGenCode/functionSignature/initFunctionSignature.bal
@@ -1,1 +1,1 @@
-(string serviceUrl, http:ClientConfiguration clientConfig = {}) returns graphql:Error?
+(string serviceUrl, http:ClientConfiguration clientConfig = {}) returns graphql:ClientError?

--- a/graphql-cli/src/test/resources/expectedGenCode/functionSignature/initFunctionSignatureWithApiKeysAndClientConfig.bal
+++ b/graphql-cli/src/test/resources/expectedGenCode/functionSignature/initFunctionSignatureWithApiKeysAndClientConfig.bal
@@ -1,1 +1,1 @@
-(ClientConfig clientConfig, ApiKeysConfig apiKeysConfig, string serviceUrl) returns graphql:Error?
+(ClientConfig clientConfig, ApiKeysConfig apiKeysConfig, string serviceUrl) returns graphql:ClientError?

--- a/graphql-cli/src/test/resources/expectedGenCode/functionSignature/initFunctionSignatureWithApiKeysConfig.bal
+++ b/graphql-cli/src/test/resources/expectedGenCode/functionSignature/initFunctionSignatureWithApiKeysConfig.bal
@@ -1,1 +1,1 @@
-(ApiKeysConfig apiKeysConfig, string serviceUrl, http:ClientConfiguration clientConfig = {}) returns graphql:Error?
+(ApiKeysConfig apiKeysConfig, string serviceUrl, http:ClientConfiguration clientConfig = {}) returns graphql:ClientError?

--- a/graphql-cli/src/test/resources/expectedGenCode/functionSignature/initFunctionSignatureWithClientConfig.bal
+++ b/graphql-cli/src/test/resources/expectedGenCode/functionSignature/initFunctionSignatureWithClientConfig.bal
@@ -1,1 +1,1 @@
-(ClientConfig clientConfig, string serviceUrl) returns graphql:Error?
+(ClientConfig clientConfig, string serviceUrl) returns graphql:ClientError?


### PR DESCRIPTION
## Purpose
> 
Some modifications were done in the GraphQL generic client. We need to address those changes in the GraphQL client generation tool. This PR address those changes

Resolves https://github.com/ballerina-platform/graphql-tools/issues/32

## Goals
> Address generic graphql client changes

## Approach
> 
- Modify generic error `graphql:Error` as `graphql:ClientError` 
- Change the module org of the generic client from `ballerinax` to `ballerina`
- Modify function signature generator with changes to generic error
- Modify function body generator with changes to headers
- Modify utils generator to add the following imports and types
  
```
import ballerina/graphql;

type OperationResponse record {| anydata...; |}|record {| anydata...; |}[]|boolean|string|int|float|();

type DataResponse record {|
   map<json?> __extensions?;
   OperationResponse ...;
|};
```
- Modify the `performDataBinding` utils function
- Modify test cases to support the above changes

## Release note
> Address generic graphql client changes

## Automation tests
 - Unit tests 
   > Done
 - Integration tests
   > Done

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> 
Ballerina Version: 2201.0.1
Operating System: Ubuntu 20.04
Java SDK: 11