### PR TITLE
Add operation type name support

### DIFF
--- a/graphql-cli/src/main/java/io/ballerina/graphql/generator/ballerina/TypesGenerator.java
+++ b/graphql-cli/src/main/java/io/ballerina/graphql/generator/ballerina/TypesGenerator.java
@@ -157,8 +157,16 @@ public class TypesGenerator {
      */
     private void addQueryResponseRecords(GraphQLSchema schema, List<String> documents, List<TypeDefinitionNode>
             typeDefinitionNodeList) throws IOException {
-        Map<String, FieldType> queryFieldsMap = SpecReader.getObjectTypeFieldsMap(schema, QUERY);
-        Map<String, FieldType> mutationFieldsMap = SpecReader.getObjectTypeFieldsMap(schema, MUTATION);
+        String queryObjectTypeName = QUERY;
+        String mutationObjectTypeName = MUTATION;
+        if (schema.getQueryType() != null) {
+            queryObjectTypeName = schema.getQueryType().getName();
+        }
+        if (schema.getMutationType() != null) {
+            mutationObjectTypeName = schema.getMutationType().getName();
+        }
+        Map<String, FieldType> queryFieldsMap = SpecReader.getObjectTypeFieldsMap(schema, queryObjectTypeName);
+        Map<String, FieldType> mutationFieldsMap = SpecReader.getObjectTypeFieldsMap(schema, mutationObjectTypeName);
         queryFieldsMap.putAll(mutationFieldsMap);
         RecordFieldNode extensionsFieldNode = getExtensionsRecField();
         Map<String, String> fragmentRecordsMap = new HashMap<>();


### PR DESCRIPTION
## Purpose
> 
Resolves https://github.com/ballerina-platform/graphql-tools/issues/34

## Goals
> Add operation type name support

## Approach
> 
- Handle operation type names for query and mutation in types generator

## Release note
> Add operation type name support

## Automation tests
 - Unit tests 
   > Done
 - Integration tests
   > Done

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> 
Ballerina Version: 2201.0.1
Operating System: Ubuntu 20.04
Java SDK: 11