### PR TITLE
Add support to pack the tool with Ballerina distribution

### DIFF
--- a/.github/workflows/build-timestamped-master.yml
+++ b/.github/workflows/build-timestamped-master.yml
@@ -1,0 +1,36 @@
+name: Build
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'ballerina-platform'
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11.0.7
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: 11
+      - name: Change to Timestamped Version
+        run: |
+          startTime=$(TZ="Asia/Kolkata" date +'%Y%m%d-%H%M00')
+          latestCommit=$(git log -n 1 --pretty=format:"%h")
+          VERSION=$((grep -w 'version' | cut -d= -f2) < gradle.properties | rev | cut --complement -d- -f1 | rev)
+          updatedVersion=$VERSION-$startTime-$latestCommit
+          echo $updatedVersion
+          sed -i "s/version=\(.*\)/version=$updatedVersion/g" gradle.properties
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Build with Gradle
+        env:
+          packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
+          packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
+        run: |
+          ./gradlew clean build publish codeCoverageReport --stacktrace --scan --console=plain 
+      - name: Generate CodeCov Report
+        uses: codecov/codecov-action@v1

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -1,0 +1,58 @@
+name: Publish release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11.0.7
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: 11
+      - name: Set version env variable
+        run: echo "VERSION=$((grep -w "version" | cut -d= -f2) < gradle.properties | rev | cut --complement -d- -f1 | rev)" >> $GITHUB_ENV
+      - name: Pre release depenency version update
+        env:
+          GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
+        run: |
+          echo "Version: ${VERSION}"
+          git config user.name ${{ secrets.BALLERINA_BOT_USERNAME }}
+          git config user.email ${{ secrets.BALLERINA_BOT_EMAIL }}
+          git checkout -b release-${VERSION}
+          sed -i 's/ballerinaLangVersion=\(.*\)-SNAPSHOT/ballerinaLangVersion=\1/g' gradle.properties
+          sed -i 's/ballerinaLangVersion=\(.*\)-[0-9]\{8\}-[0-9]\{6\}-.*$/ballerinaLangVersion=\1/g' gradle.properties
+          sed -i 's/stdlib\(.*\)=\(.*\)-SNAPSHOT/stdlib\1=\2/g' gradle.properties
+          sed -i 's/stdlib\(.*\)=\(.*\)-[0-9]\{8\}-[0-9]\{6\}-.*$/stdlib\1=\2/g' gradle.properties
+          git add gradle.properties
+          git commit -m "Move dependencies to stable version" || echo "No changes to commit"
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Publish artifact
+        env:
+          GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_ACCESS_TOKEN }}
+          packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
+          packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
+        run: |
+          ./gradlew release -Prelease.useAutomaticVersion=true
+          ./gradlew -Pversion=${VERSION} publish -x test -PpublishToCentral=true
+      - name: Create Github release from the release tag
+        run: |
+          curl --request POST 'https://api.github.com/repos/ballerina-platform/graphql-tools/releases' \
+          --header 'Accept: application/vnd.github.v3+json' \
+          --header 'Authorization: Bearer ${{ secrets.BALLERINA_BOT_TOKEN }}' \
+          --header 'Content-Type: application/json' \
+          --data-raw '{
+              "tag_name": "v'"$VERSION"'",
+              "name": "graphql-tools-v'"$VERSION"'"
+          }'
+      - name: Post release PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
+        run: |
+          curl -fsSL https://github.com/github/hub/raw/master/script/get | bash -s 2.14.1
+          bin/hub pull-request -m "[Automated] Sync master after $VERSION release"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -28,3 +28,22 @@ jobs:
             ./gradlew build codeCoverageReport --stacktrace --scan --console=plain --no-daemon
       - name: Generate Codecov Report
         uses: codecov/codecov-action@v2
+
+  windows-build:
+
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11.0.7
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: 11
+      - name: Build with Gradle
+        env:
+          packageUser: ${{ github.actor }}
+          packagePAT: ${{ secrets.GITHUB_TOKEN }}
+          WORKING_DIR: ./graphql-cli
+          JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF8
+        run: ./gradlew.bat build --stacktrace --scan --console=plain --no-daemon

--- a/.github/workflows/stale_check.yaml
+++ b/.github/workflows/stale_check.yaml
@@ -1,0 +1,19 @@
+name: 'Close stale pull requests'
+
+on:
+  schedule:
+    - cron: '30 19 * * *'
+  workflow_dispatch:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v3
+        with:
+          stale-pr-message: 'This PR has been open for more than 15 days with no activity. This will be closed in 3 days unless the `stale` label is removed or commented.'
+          close-pr-message: 'Closed PR due to inactivity for more than 18 days.'
+          days-before-pr-stale: 15
+          days-before-pr-close: 3
+          days-before-issue-stale: -1
+          days-before-issue-close: -1

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,9 @@
 plugins {
     id 'java'
     id 'jacoco'
-    id "com.github.johnrengelman.shadow" version "5.2.0"
+    id "com.github.johnrengelman.shadow" version "${githubJohnrengelmanShadowVersion}"
+    id "de.undercouch.download" version "${underCouchDownloadVersion}"
+    id "net.researchgate.release" version "${researchgateReleaseVersion}"
 }
 
 ext.ballerinaLangVersion = project.ballerinaLangVersion
@@ -33,8 +35,14 @@ ext.orgJsonVersion = project.orgJsonVersion
 ext.picocliVersion = project.picocliVersion
 ext.puppycrawlCheckstyleVersion = "8.18"
 
+def packageName = "graphql"
+
 allprojects {
+    group = project.group
+    version = project.version
+
     apply plugin: 'checkstyle'
+    apply plugin: 'maven-publish'
 
     repositories {
         mavenLocal()
@@ -92,6 +100,24 @@ subprojects {
     }
 }
 
+def moduleVersion = project.version.replace("-SNAPSHOT", "")
+
+release {
+    // Disable check snapshots temporarily
+    failOnPublishNeeded = false
+    versionPropertyFile = 'gradle.properties'
+    tagTemplate = 'v${version}'
+    git {
+        // To release from any branch
+        requireBranch = "release-${moduleVersion}"
+        pushToRemote = 'origin'
+    }
+}
+
+tasks.withType(JavaCompile) {
+    options.encoding = 'UTF-8'
+}
+
 task codeCoverageReport(type: JacocoReport) {
     dependsOn = subprojects.test
 
@@ -113,3 +139,56 @@ task codeCoverageReport(type: JacocoReport) {
         true
     }
 }
+
+def artifactCacheParent = file("$project.projectDir/build/cache_parent/")
+def artifactLibParent = file("$project.projectDir/build/lib_parent/")
+def targetGraphqlCliJar = file("$project.rootDir/graphql-cli/build/libs/graphql-cli-${project.version}.jar")
+
+jar {
+    manifest {
+        attributes('Implementation-Title': project.name,
+                'Implementation-Version': project.version)
+    }
+}
+
+task directoryBuild {
+    inputs.dir file(project.projectDir)
+    doLast {
+        copy {
+            from targetGraphqlCliJar
+            into file("$artifactLibParent/libs")
+        }
+    }
+
+    outputs.dir artifactCacheParent
+    outputs.dir artifactLibParent
+}
+
+task createArtifactZip(type: Zip) {
+    destinationDirectory = file("${buildDir}/distributions")
+    from directoryBuild
+}
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            artifact source: createArtifactZip, extension: 'zip'
+        }
+    }
+
+    repositories {
+        maven {
+            name = "GitHubPackages"
+            url = uri("https://maven.pkg.github.com/ballerina-platform/graphql-tools")
+            credentials {
+                username = System.getenv("packageUser")
+                password = System.getenv("packagePAT")
+            }
+        }
+    }
+}
+
+directoryBuild.dependsOn ":${packageName}-cli:build"
+build.dependsOn directoryBuild
+
+publish.dependsOn build

--- a/config/checkstyle/build.gradle
+++ b/config/checkstyle/build.gradle
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+plugins {
+    id "de.undercouch.download"
+}
+
+task downloadMultipleFiles(type: Download) {
+    src([
+            'https://raw.githubusercontent.com/wso2/code-quality-tools/v1.3/checkstyle/checkstyle.xml',
+            'https://raw.githubusercontent.com/wso2/code-quality-tools/v1.3/checkstyle/suppressions.xml'
+    ])
+    overwrite false
+    onlyIfNewer true
+    dest buildDir
+}
+
+jar {
+    enabled = false
+}
+
+clean {
+    enabled = false
+}
+
+artifacts.add('default', file("${rootDir}/config/checkstyle/checkstyle.xml")) {
+    builtBy('downloadMultipleFiles')
+}
+
+artifacts.add('default', file("${rootDir}/config/checkstyle/suppressions.xml")) {
+    builtBy('downloadMultipleFiles')
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,12 @@
 org.gradle.caching=true
 group=io.ballerina
-version=1.0.0
+version=0.0.1-SNAPSHOT
 
 #dependency
 ballerinaLangVersion=2201.0.1
+githubJohnrengelmanShadowVersion=5.2.0
+underCouchDownloadVersion=4.0.4
+researchgateReleaseVersion=2.8.0
 testngVersion=7.3.0
 slf4jVersion=1.7.30
 commonsLoggingVersion=1.2

--- a/graphql-cli/build.gradle
+++ b/graphql-cli/build.gradle
@@ -20,6 +20,9 @@ apply plugin: "jacoco"
 
 configurations {
     balTools
+    dist {
+        transitive true
+    }
 }
 
 dependencies {
@@ -35,9 +38,9 @@ dependencies {
     implementation "org.yaml:snakeyaml:${snakeYamlVersion}" // NEW
     implementation "com.graphql-java:graphql-java:${graphqlJavaVersion}" // NEW
     implementation "org.json:json:${orgJsonVersion}" // NEW
-    shadow "com.graphql-java:graphql-java:${graphqlJavaVersion}" // NEW
-    shadow "com.google.guava:guava:${googleGuavaVersion}" // NEW
-    shadow "org.json:json:${orgJsonVersion}" // NEW
+    dist "com.graphql-java:graphql-java:${graphqlJavaVersion}" // NEW
+    dist "com.google.guava:guava:${googleGuavaVersion}" // NEW
+    dist "org.json:json:${orgJsonVersion}" // NEW
 
     balTools ("org.ballerinalang:jballerina-tools:${ballerinaLangVersion}") {
         transitive = false
@@ -86,8 +89,12 @@ task copyStdlibs(type: Copy) {
     }
 }
 
-shadowJar {
-    configurations = [project.configurations.shadow]
+jar {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    dependsOn configurations.dist
+    from { configurations.dist.collect { it.isDirectory() ? it : zipTree(it) } } {
+        exclude 'META-INF/*.RSA', 'META-INF/*.SF', 'META-INF/*.DSA'
+    }
 }
 
 build.dependsOn(shadowJar)

--- a/graphql-cli/src/main/java/io/ballerina/graphql/cmd/GraphqlCmd.java
+++ b/graphql-cli/src/main/java/io/ballerina/graphql/cmd/GraphqlCmd.java
@@ -150,11 +150,8 @@ public class GraphqlCmd implements BLauncherCmd {
     private void validateInputFlags() throws CmdException {
         // Check if CLI help flag argument is present
         if (helpFlag) {
-            // TODO: Send a PR with cli-help/ballerina-graphql.help file to
-            //  https://github.com/ballerina-platform/ballerina-lang/tree/master/cli/ballerina-cli/src/main/resources/
-//            String commandUsageInfo = BLauncherCmd.getCommandUsageInfo(getName());
-//            outStream.println(commandUsageInfo);
-            Runtime.getRuntime().exit(0);
+            String commandUsageInfo = BLauncherCmd.getCommandUsageInfo(getName());
+            outStream.println(commandUsageInfo);
             return;
         }
 
@@ -165,10 +162,8 @@ public class GraphqlCmd implements BLauncherCmd {
                 throw new CmdException(MESSAGE_FOR_MISSING_INPUT_ARGUMENT);
             }
         } else {
-            // TODO: Send a PR with cli-help/ballerina-graphql.help file to
-            //  https://github.com/ballerina-platform/ballerina-lang/tree/master/cli/ballerina-cli/src/main/resources/
-//            String commandUsageInfo = BLauncherCmd.getCommandUsageInfo(getName());
-//            outStream.println(commandUsageInfo);
+            String commandUsageInfo = BLauncherCmd.getCommandUsageInfo(getName());
+            outStream.println(commandUsageInfo);
             exitError(this.exitWhenFinish);
         }
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,14 @@
+plugins {
+    id "com.gradle.enterprise" version "3.2"
+}
+
 rootProject.name = 'graphql-tools'
+include(':config:checkstyle')
 include(':graphql-cli')
+
+gradleEnterprise {
+    buildScan {
+        termsOfServiceUrl = 'https://gradle.com/terms-of-service'
+        termsOfServiceAgree = 'yes'
+    }
+}


### PR DESCRIPTION
## Purpose
> 
Resolves https://github.com/ballerina-platform/graphql-tools/issues/36

## Goals
> Add support for GraphQL tool to pack with Ballerina distribution

## Approach
> 
- Add necessary GitHub workflows
- Add release and GitHub package publish tasks to Gradle file
- Enable `commandUsageInfo`
- Bump tool version to `0.0.1-SNAPSHOT`

## Release note
> Add support for GraphQL tool to pack with Ballerina distribution

## Automation tests
 - Unit tests 
   > Done
 - Integration tests
   > Done

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> 
Ballerina Version: 2201.0.1
Operating System: Ubuntu 20.04
Java SDK: 11