### PR TITLE
Bump tool version to 0.0.3-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=io.ballerina
-version=0.0.2
+version=0.0.3-SNAPSHOT
 
 #dependency
 ballerinaLangVersion=2201.0.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=io.ballerina
-version=0.0.2-SNAPSHOT
+version=0.0.2
 
 #dependency
 ballerinaLangVersion=2201.0.2


### PR DESCRIPTION
## Purpose
> Bump tool version to 0.0.3-SNAPSHOT

## Test environment
> 
Ballerina Version: 2201.0.2
Operating System: Ubuntu 20.04
Java SDK: 11