### PR TITLE
Bump tool version to 0.2.0-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=io.ballerina
-version=0.1.0
+version=0.2.0-SNAPSHOT
 
 #dependency
 ballerinaLangVersion=2201.1.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=io.ballerina
-version=0.1.0-SNAPSHOT
+version=0.1.0
 
 #dependency
 ballerinaLangVersion=2201.1.0


### PR DESCRIPTION
## Purpose
> Bump tool version to 0.2.0-SNAPSHOT

## Test environment
> 
Ballerina Version: 2201.1.0
Operating System: Ubuntu 20.04
Java SDK: 11