### PR TITLE
Fix help flag issue

### DIFF
--- a/graphql-cli/src/main/java/io/ballerina/graphql/cmd/GraphqlCmd.java
+++ b/graphql-cli/src/main/java/io/ballerina/graphql/cmd/GraphqlCmd.java
@@ -152,7 +152,7 @@ public class GraphqlCmd implements BLauncherCmd {
         if (helpFlag) {
             String commandUsageInfo = BLauncherCmd.getCommandUsageInfo(getName());
             outStream.println(commandUsageInfo);
-            return;
+            exitError(this.exitWhenFinish);
         }
 
         // Check if CLI input path flag argument is present


### PR DESCRIPTION
## Purpose
> Fix help flag (-h, --help) issue.

Resolves https://github.com/ballerina-platform/graphql-tools/issues/81

## Goals
> Remove unexpected output in `bal graphql -h` command

## Approach
> Use `exitError(this.exitWhenFinish);` instead of `return;`

## Release note
> Remove unexpected output in `bal graphql -h` command

## Automation tests
 - Unit tests 
   > Done
 - Integration tests
   > Done

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes


## Test environment
> 
Ballerina Version: 2201.2.0-rc3
Operating System: Ubuntu 20.04
Java SDK: 11