### PR TITLE
Bump ballerina version to 2201.2.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ group=io.ballerina
 version=0.2.0-SNAPSHOT
 
 #dependency
-ballerinaLangVersion=2201.2.0-rc3.2
+ballerinaLangVersion=2201.2.0
 githubJohnrengelmanShadowVersion=5.2.0
 underCouchDownloadVersion=4.0.4
 researchgateReleaseVersion=2.8.0


### PR DESCRIPTION
## Purpose
> Bump Ballerina version to 2201.2.0

Resolves https://github.com/ballerina-platform/graphql-tools/issues/87

## Goals
> Bump Ballerina version to 2201.2.0

## Approach
> Bump Ballerina version to 2201.2.0

## Release note
> Bump Ballerina version to 2201.2.0

## Automation tests
 - Unit tests 
   > Done
 - Integration tests
   > Done

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> 
Ballerina Version: 2201.2.0
Operating System: Ubuntu 20.04
Java SDK: 11