### PR TITLE
Skip Tests that not Compatible With Windows Environment

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -46,4 +46,4 @@ jobs:
           packagePAT: ${{ secrets.GITHUB_TOKEN }}
           WORKING_DIR: ./graphql-cli
           JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF8
-        run: ./gradlew.bat build --stacktrace --scan --console=plain --no-daemon
+        run: ./gradlew.bat build -Pdisable=invalid_permission --stacktrace --scan --console=plain --no-daemon

--- a/graphql-cli/build.gradle
+++ b/graphql-cli/build.gradle
@@ -17,6 +17,7 @@
 
 apply plugin: "com.github.johnrengelman.shadow"
 apply plugin: "jacoco"
+import org.apache.tools.ant.taskdefs.condition.Os
 
 configurations {
     balTools
@@ -112,6 +113,9 @@ test {
     systemProperty "ballerina.home", bDistribution
 
     useTestNG() {
+        if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+            excludeGroups('invalid_permission')
+        }
         suites "src/test/resources/testng.xml"
     }
     finalizedBy jacocoTestReport

--- a/graphql-cli/build.gradle
+++ b/graphql-cli/build.gradle
@@ -122,9 +122,7 @@ test {
     systemProperty "ballerina.home", bDistribution
 
     useTestNG() {
-        if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-            excludeGroups(disableGroups)
-        }
+        excludeGroups(disableGroups)
         suites "src/test/resources/testng.xml"
     }
     finalizedBy jacocoTestReport

--- a/graphql-cli/build.gradle
+++ b/graphql-cli/build.gradle
@@ -106,15 +106,24 @@ jar {
     }
 }
 
+def disableGroups = ""
+
+task initializeVariables {
+    if (project.hasProperty("disable")) {
+        disableGroups = project.findProperty("disable")
+    }
+}
+
 test {
     dependsOn {
         copyStdlibs
+        initializeVariables
     }
     systemProperty "ballerina.home", bDistribution
 
     useTestNG() {
         if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-            excludeGroups('invalid_permission')
+            excludeGroups(disableGroups)
         }
         suites "src/test/resources/testng.xml"
     }

--- a/graphql-cli/src/test/java/io/ballerina/graphql/cmd/SdlSchemaGenerationTest.java
+++ b/graphql-cli/src/test/java/io/ballerina/graphql/cmd/SdlSchemaGenerationTest.java
@@ -122,7 +122,7 @@ public class SdlSchemaGenerationTest extends GraphqlTest {
     @Test(description = "Test successful GraphQL command execution with multiple services")
     public void testSdlGenerationWithMultipleServices2() {
         Path graphqlService = resourceDir.resolve(Paths.get("graphqlServices/valid", "service4.bal"));
-        String[] args = {"-i", graphqlService.toString(), "-o", this.tmpDir.toString(), "-s", "/"};
+        String[] args = {"-i", graphqlService.toString(), "-o", this.tmpDir.toString()};
         GraphqlCmd graphqlCmd = new GraphqlCmd(printStream, tmpDir, false);
         new CommandLine(graphqlCmd).parseArgs(args);
         try {
@@ -152,7 +152,7 @@ public class SdlSchemaGenerationTest extends GraphqlTest {
     @Test(description = "Test successful GraphQL command execution with multiple services in a bal project")
     public void testSdlGenerationWithMultipleServicesInProject() {
         Path graphqlService = resourceDir.resolve(Paths.get("graphqlServices/valid/project_2", "main.bal"));
-        String[] args = {"-i", graphqlService.toString(), "-o", this.tmpDir.toString(), "-s", "/"};
+        String[] args = {"-i", graphqlService.toString(), "-o", this.tmpDir.toString()};
         GraphqlCmd graphqlCmd = new GraphqlCmd(printStream, tmpDir, false);
         new CommandLine(graphqlCmd).parseArgs(args);
         try {

--- a/graphql-cli/src/test/java/io/ballerina/graphql/cmd/SdlSchemaGenerationTest.java
+++ b/graphql-cli/src/test/java/io/ballerina/graphql/cmd/SdlSchemaGenerationTest.java
@@ -310,56 +310,50 @@ public class SdlSchemaGenerationTest extends GraphqlTest {
         }
     }
 
-    @Test(description = "Test GraphQL command execution with readonly output path")
+    @Test(
+        groups = {"invalid_permission"},
+        description = "Test GraphQL command execution with readonly output path"
+    )
     public void testExecuteWithReadonlyOutputPath() {
         Path graphqlService = resourceDir.resolve(Paths.get("graphqlServices/invalid", "service2.bal"));
         try {
             Path outPath = Paths.get(tmpDir.toString(), "new");
             Files.createDirectories(outPath);
             File file = new File(outPath.toString());
-            boolean setReadonly = file.setReadOnly();
-            if (setReadonly) {
-                // The `setReadOnly()` method doesn't work as expected in 'windows' environments. Hence,
-                // added an 'if' block to skip this test in 'windows' until find a workaround
-                String[] args = {"-i", graphqlService.toString(), "-o", outPath.toString()};
-                GraphqlCmd graphqlCmd = new GraphqlCmd(printStream, tmpDir, false);
-                new CommandLine(graphqlCmd).parseArgs(args);
-                graphqlCmd.execute();
-                String output = readOutput(true);
-                String expectedMessage = "SDL schema generation failed: " + outPath +
-                        "/schema_graphql_new.graphql (Permission denied)";
-                file.setWritable(true);
-                Assert.assertTrue(output.contains(expectedMessage));
-            } else {
-                Assert.assertTrue(true);
-            }
+            file.setReadOnly();
+            String[] args = {"-i", graphqlService.toString(), "-o", outPath.toString()};
+            GraphqlCmd graphqlCmd = new GraphqlCmd(printStream, tmpDir, false);
+            new CommandLine(graphqlCmd).parseArgs(args);
+            graphqlCmd.execute();
+            String output = readOutput(true);
+            String expectedMessage = "SDL schema generation failed: " + outPath +
+                    "/schema_graphql_new.graphql (Permission denied)";
+            file.setWritable(true);
+            Assert.assertTrue(output.contains(expectedMessage));
         } catch (BLauncherException | IOException e) {
             Assert.fail(e.toString());
         }
     }
 
-    @Test(description = "Test GraphQL command execution with bal file without read permission")
+    @Test(
+        groups = {"invalid_permission"},
+        description = "Test GraphQL command execution with bal file without read permission"
+    )
     public void testSdlGenerationWithBalFileWithoutReadPermission() {
         Path graphqlService = Paths.get(tmpDir.toString(), "service4.bal");
         try {
             Files.createFile(graphqlService);
             File file = new File(graphqlService.toString());
-            boolean setWritable = file.setReadable(false);
-            if (setWritable) {
-                // The `setReadable()` method doesn't work as expected in 'windows' environments. Hence,
-                // added an 'if' block to skip this test in `windows` until find a workaround
-                String[] args = {"-i", file.getPath(), "-o", this.tmpDir.toString()};
-                GraphqlCmd graphqlCmd = new GraphqlCmd(printStream, tmpDir, false);
-                new CommandLine(graphqlCmd).parseArgs(args);
-                graphqlCmd.execute();
-                String output = readOutput(true);
-                String expectedMessage = "SDL schema generation failed: " +
-                        "Cannot read provided Ballerina file (Permission denied)";
-                file.setReadable(true);
-                Assert.assertTrue(output.contains(expectedMessage));
-            } else {
-                Assert.assertTrue(true);
-            }
+            file.setReadable(false);
+            String[] args = {"-i", file.getPath(), "-o", this.tmpDir.toString()};
+            GraphqlCmd graphqlCmd = new GraphqlCmd(printStream, tmpDir, false);
+            new CommandLine(graphqlCmd).parseArgs(args);
+            graphqlCmd.execute();
+            String output = readOutput(true);
+            String expectedMessage = "SDL schema generation failed: " +
+                    "Cannot read provided Ballerina file (Permission denied)";
+            file.setReadable(true);
+            Assert.assertTrue(output.contains(expectedMessage));
         } catch (BLauncherException | IOException e) {
             Assert.fail(e.toString());
         }

--- a/graphql-schema-file-generator/src/main/java/io/ballerina/graphql/schema/generator/SdlSchemaGenerator.java
+++ b/graphql-schema-file-generator/src/main/java/io/ballerina/graphql/schema/generator/SdlSchemaGenerator.java
@@ -166,7 +166,9 @@ public class SdlSchemaGenerator {
                     addToList(serviceBasePath, actualBasePath, updatedServiceName, schema, availableServices,
                             schemasToGenerate);
                 }
-            } else if (syntaxKind == SyntaxKind.MODULE_VAR_DECL) {
+            } else if (syntaxKind == SyntaxKind.MODULE_VAR_DECL && serviceBasePath == null) {
+                // if the service base path is given, the schema is not generated for the services with
+                // module level variable declarations since base path is unknown.
                 ModuleVariableDeclarationNode moduleVariableNode = (ModuleVariableDeclarationNode) node;
                 if (!isGraphQLServiceObjectDeclaration(moduleVariableNode)) {
                     continue;


### PR DESCRIPTION
## Purpose
1. Skip tests that are not compatible with the `windows` environment.
2. Skip schema generation for services with variable declaration when there is the `--service` is present in the CLI command. To generate the schema for these services, the command can be run without the `--service` flag. This is because of not having a way to filter the service declared as a variable by `service base path`.