### PR TITLE
Return a Proper Error Message for Unsupported Operations

### DIFF
--- a/graphql-cli/src/test/java/io/ballerina/graphql/cmd/GraphqlCmdTest.java
+++ b/graphql-cli/src/test/java/io/ballerina/graphql/cmd/GraphqlCmdTest.java
@@ -432,4 +432,44 @@ public class GraphqlCmdTest extends GraphqlTest {
             Assert.fail(output);
         }
     }
+
+    @Test(description = "Test error message of unsupported operations in schema")
+    public void testExecuteWithUnsupportedOperations1() {
+        Path graphqlConfigYaml =
+                resourceDir.resolve(Paths.get("specs", "graphql-schema-with-unsupported-operations.yaml"));
+        String[] args = {"-i", graphqlConfigYaml.toString(), "-o", this.tmpDir.toString()};
+        GraphqlCmd graphqlCmd = new GraphqlCmd(printStream, tmpDir, false);
+        new CommandLine(graphqlCmd).parseArgs(args);
+
+        String output = "";
+        try {
+            graphqlCmd.execute();
+            output = readOutput(true);
+            Assert.assertTrue(output.contains(
+                    "The provided schema includes operations that are not supported by the client generation."));
+        } catch (BLauncherException | IOException e) {
+            output = e.toString();
+            Assert.fail(output);
+        }
+    }
+
+    @Test(description = "Test error message of unsupported operations in schema")
+    public void testExecuteWithUnsupportedOperations2() {
+        Path graphqlConfigYaml =
+                resourceDir.resolve(Paths.get("specs", "graphql-schema-with-subscription.yaml"));
+        String[] args = {"-i", graphqlConfigYaml.toString(), "-o", this.tmpDir.toString()};
+        GraphqlCmd graphqlCmd = new GraphqlCmd(printStream, tmpDir, false);
+        new CommandLine(graphqlCmd).parseArgs(args);
+
+        String output = "";
+        try {
+            graphqlCmd.execute();
+            output = readOutput(true);
+            Assert.assertTrue(output.contains(
+                    "The provided schema includes operations that are not supported by the client generation."));
+        } catch (BLauncherException | IOException e) {
+            output = e.toString();
+            Assert.fail(output);
+        }
+    }
 }

--- a/graphql-cli/src/test/resources/specs/graphql-schema-with-subscription.yaml
+++ b/graphql-cli/src/test/resources/specs/graphql-schema-with-subscription.yaml
@@ -1,0 +1,3 @@
+schema: src/test/resources/specs/schema-with-subscription.graphql
+documents:
+  - src/test/resources/specs/queries/subscription-queries.graphql

--- a/graphql-cli/src/test/resources/specs/graphql-schema-with-unsupported-operations.yaml
+++ b/graphql-cli/src/test/resources/specs/graphql-schema-with-unsupported-operations.yaml
@@ -1,0 +1,3 @@
+schema: src/test/resources/specs/schema-with-scalar.graphql
+documents:
+  - src/test/resources/specs/queries/scalar-queries.graphql

--- a/graphql-cli/src/test/resources/specs/queries/scalar-queries.graphql
+++ b/graphql-cli/src/test/resources/specs/queries/scalar-queries.graphql
@@ -1,0 +1,3 @@
+mutation MyMutation {
+    updateName(id: 1, name: "Potter")
+}

--- a/graphql-cli/src/test/resources/specs/queries/subscription-queries.graphql
+++ b/graphql-cli/src/test/resources/specs/queries/subscription-queries.graphql
@@ -1,0 +1,3 @@
+subscription MySub {
+    names
+}

--- a/graphql-cli/src/test/resources/specs/schema-with-scalar.graphql
+++ b/graphql-cli/src/test/resources/specs/schema-with-scalar.graphql
@@ -1,0 +1,13 @@
+type Query {
+    profile(id: Int!): Profile!
+}
+
+type Profile {
+    id: Int!
+    name: String!
+    age: Int!
+}
+
+type Mutation {
+    updateName(id: Int!, name: String!): String!
+}

--- a/graphql-cli/src/test/resources/specs/schema-with-subscription.graphql
+++ b/graphql-cli/src/test/resources/specs/schema-with-subscription.graphql
@@ -1,0 +1,7 @@
+type Query {
+    names: [String!]!
+}
+
+type Subscription {
+    names: String!
+}

--- a/graphql-code-generator/src/main/java/io/ballerina/graphql/generator/client/generator/ClientCodeGenerator.java
+++ b/graphql-code-generator/src/main/java/io/ballerina/graphql/generator/client/generator/ClientCodeGenerator.java
@@ -55,6 +55,9 @@ public class ClientCodeGenerator extends CodeGenerator {
             writeGeneratedSources(genSources, Path.of(outputPath));
         } catch (IOException e) {
             throw new ClientCodeGenerationException(e.getMessage(), project.getName());
+        } catch (NullPointerException e) {
+            throw new ClientCodeGenerationException("The provided schema includes operations that are not supported " +
+                    "by the client generation.", project.getName());
         }
     }
 


### PR DESCRIPTION
## Purpose
Fixes: [#229](https://github.com/ballerina-platform/graphql-tools/issues/229)

## Example
```shell
ERROR [(root:):(1:1,1:1)] Ballerina code generation related error occurred. The provided schema includes operations that are not supported by the client generation.
Please check project : root
```

