### PR TITLE
Migrate to Gradle 9.5.1 and Java 25

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,11 +10,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 21
-        uses: actions/setup-java@v3
+      - name: Set up JDK 25
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 21.0.3
+          java-version: 25
       - name: Build with Gradle
         env:
           packageUser: ${{ github.actor }}
@@ -31,11 +31,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 21
-        uses: actions/setup-java@v3
+      - name: Set up JDK 25
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 21.0.3
+          java-version: 25
       - name: Build with Gradle
         env:
           packageUser: ${{ github.actor }}

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@
 
 plugins {
     id 'jacoco'
-    id "com.github.johnrengelman.shadow"
+    id "com.gradleup.shadow"
     id "de.undercouch.download"
     id "net.researchgate.release"
 }
@@ -70,6 +70,14 @@ allprojects {
 }
 
 subprojects {
+
+    plugins.withId('java') {
+        java {
+            toolchain {
+                languageVersion = JavaLanguageVersion.of(25)
+            }
+        }
+    }
 
     configurations {
         ballerinaStdLibs
@@ -152,9 +160,9 @@ task codeCoverageReport(type: JacocoReport) {
         xml.required = true
         html.required = true
         csv.required = true
-        xml.destination = file("${buildDir}/reports/jacoco/report.xml")
-        html.destination = file("${buildDir}/reports/jacoco/report.html")
-        csv.destination = file("${buildDir}/reports/jacoco/report.csv")
+        xml.outputLocation = layout.buildDirectory.file("reports/jacoco/report.xml")
+        html.outputLocation = layout.buildDirectory.dir("reports/jacoco/html")
+        csv.outputLocation = layout.buildDirectory.file("reports/jacoco/report.csv")
     }
 
     onlyIf = {
@@ -162,7 +170,7 @@ task codeCoverageReport(type: JacocoReport) {
     }
 }
 
-task build {
+tasks.named('build') {
     dependsOn ":${packageName}-tool:build"
 }
 

--- a/config/checkstyle/build.gradle
+++ b/config/checkstyle/build.gradle
@@ -27,7 +27,7 @@ task downloadCheckstyleRuleFiles(type: Download) {
     ])
     overwrite false
     onlyIfNewer true
-    dest buildDir
+    dest layout.buildDirectory.get().asFile
 }
 
 jar {
@@ -38,10 +38,10 @@ clean {
     enabled = false
 }
 
-artifacts.add('default', file("$project.buildDir/checkstyle.xml")) {
+artifacts.add('default', layout.buildDirectory.file("checkstyle.xml")) {
     builtBy('downloadCheckstyleRuleFiles')
 }
 
-artifacts.add('default', file("$project.buildDir/suppressions.xml")) {
+artifacts.add('default', layout.buildDirectory.file("suppressions.xml")) {
     builtBy('downloadCheckstyleRuleFiles')
 }

--- a/config/resources/Ballerina.toml
+++ b/config/resources/Ballerina.toml
@@ -5,4 +5,4 @@ version = "@toml.version@"
 authors = ["Ballerina"]
 keywords = ["graphql", "graphql tool", "gql"]
 license = ["Apache-2.0"]
-distribution = "2201.13.0"
+distribution = "2201.14.0-20260527-050400-74f7e6bf"

--- a/config/resources/Ballerina.toml
+++ b/config/resources/Ballerina.toml
@@ -5,4 +5,4 @@ version = "@toml.version@"
 authors = ["Ballerina"]
 keywords = ["graphql", "graphql tool", "gql"]
 license = ["Apache-2.0"]
-distribution = "2201.14.0-20260527-050400-74f7e6bf"
+distribution = "2201.14.0"

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ group=io.ballerina
 version=0.14.1-SNAPSHOT
 org.gradle.jvmargs=-Xmx4096M
 
-ballerinaLangVersion=2201.13.5-20260717-102000-26087aa2
+ballerinaLangVersion=2201.14.0-20260527-050400-74f7e6bf
 jacocoVersion=0.8.14
 checkstylePluginVersion=10.12.1
 shadowJarPluginVersion=8.3.5

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ version=0.14.1-SNAPSHOT
 org.gradle.jvmargs=-Xmx4096M
 
 ballerinaLangVersion=2201.14.0-20260527-050400-74f7e6bf
-jacocoVersion=0.8.13
+jacocoVersion=0.8.14
 checkstylePluginVersion=10.12.1
 shadowJarPluginVersion=8.3.5
 downloadPluginVersion=5.4.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,11 +3,12 @@ group=io.ballerina
 version=0.14.1-SNAPSHOT
 org.gradle.jvmargs=-Xmx4096M
 
-ballerinaLangVersion=2201.13.0
+ballerinaLangVersion=2201.14.0-20260527-050400-74f7e6bf
+jacocoVersion=0.8.13
 checkstylePluginVersion=10.12.1
-shadowJarPluginVersion=8.1.1
+shadowJarPluginVersion=8.3.5
 downloadPluginVersion=5.4.0
-releasePluginVersion=2.8.0
+releasePluginVersion=3.1.0
 testngVersion=7.6.1
 slf4jVersion=1.7.30
 commonsLang3Version=3.9
@@ -17,7 +18,7 @@ graphqlJavaVersion=21.5
 snakeYamlVersion=2.0
 orgJsonVersion=20231013
 picocliVersion=4.7.4
-ballerinaGradlePluginVersion=2.3.0
+ballerinaGradlePluginVersion=4.0.0
 
 # Standard Library Dependencies
 # Level 01

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ group=io.ballerina
 version=0.14.1-SNAPSHOT
 org.gradle.jvmargs=-Xmx4096M
 
-ballerinaLangVersion=2201.14.0-20260527-050400-74f7e6bf
+ballerinaLangVersion=2201.13.5-20260717-102000-26087aa2
 jacocoVersion=0.8.14
 checkstylePluginVersion=10.12.1
 shadowJarPluginVersion=8.3.5

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -5,3 +5,4 @@ networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionSha256Sum=bafc141b619ad6350fd975fc903156dd5c151998cc8b058e8c1044ab5f7b031f

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/graphql-cli/build.gradle
+++ b/graphql-cli/build.gradle
@@ -17,7 +17,7 @@
 
 plugins {
     id "java"
-    id "com.github.johnrengelman.shadow"
+    id "com.gradleup.shadow"
     id "jacoco"
     id "checkstyle"
 }
@@ -72,13 +72,13 @@ checkstyle {
 checkstyleMain.dependsOn(":checkstyle:downloadCheckstyleRuleFiles")
 checkstyleTest.dependsOn(":checkstyle:downloadCheckstyleRuleFiles")
 
-def bDistribution = file("$project.buildDir/extracted-distribution/jballerina-tools-${ballerinaLangVersion}")
+def bDistribution = layout.buildDirectory.dir("extracted-distribution/jballerina-tools-${ballerinaLangVersion}").get().asFile
 task jBallerinaPack {
     doLast {
         configurations.jbalTools.resolvedConfiguration.resolvedArtifacts.each { artifact ->
             copy {
                 from project.zipTree(artifact.getFile())
-                into new File(project.buildDir, "extracted-distribution/")
+                into layout.buildDirectory.dir("extracted-distribution/").get().asFile
             }
         }
     }
@@ -91,7 +91,7 @@ task unpackStdLibs() {
         configurations.ballerinaStdLibs.resolvedConfiguration.resolvedArtifacts.each { artifact ->
             copy {
                 from project.zipTree(artifact.getFile())
-                into new File("${project.buildDir}/extracted-distribution/" + artifact.name + "-zip")
+                into layout.buildDirectory.dir("extracted-distribution/" + artifact.name + "-zip").get().asFile
             }
         }
     }
@@ -99,13 +99,13 @@ task unpackStdLibs() {
 
 task copyStdlibs(type: Copy) {
     dependsOn(unpackStdLibs)
-    def ballerinaDist = "$project.buildDir/extracted-distribution/jballerina-tools-${ballerinaLangVersion}"
+    def ballerinaDist = layout.buildDirectory.dir("extracted-distribution/jballerina-tools-${ballerinaLangVersion}").get().asFile
     into ballerinaDist
 
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     /* Standard Libraries */
     configurations.ballerinaStdLibs.resolvedConfiguration.resolvedArtifacts.each { artifact ->
-        def artifactExtractedPath = "${project.buildDir}/extracted-distribution/" + artifact.name + "-zip"
+        def artifactExtractedPath = layout.buildDirectory.dir("extracted-distribution/" + artifact.name + "-zip").get().asFile
         into("repo/bala") {
             from "${artifactExtractedPath}/bala/"
         }
@@ -118,8 +118,8 @@ task copyStdlibs(type: Copy) {
 task copyJar(type: Copy) {
     from "$project.rootDir/graphql-schema-file-generator/build/libs/graphql-schema-file-generator-${version}.jar"
     from "$project.rootDir/graphql-code-generator/build/libs/graphql-code-generator-${version}.jar"
-    from "$project.buildDir/libs/graphql-cli-${version}.jar"
-    into "$project.buildDir/extracted-distribution/jballerina-tools-${ballerinaLangVersion}/bre/lib"
+    from layout.buildDirectory.dir("libs").get().asFile.toString() + "/graphql-cli-${version}.jar"
+    into layout.buildDirectory.dir("extracted-distribution/jballerina-tools-${ballerinaLangVersion}/bre/lib").get().asFile
 }
 
 jar {
@@ -144,7 +144,7 @@ task initializeVariables {
 }
 
 test {
-    systemProperties = [ "target.dir": "$project.buildDir",
+    systemProperties = [ "target.dir": layout.buildDirectory.get().asFile.toString(),
                          "distributions.dir": bDistribution,
                          "ballerina.home": bDistribution,
                          "ballerina.version": "jballerina-tools-${ballerinaLangVersion}"
@@ -168,8 +168,8 @@ test {
 }
 
 jacoco {
-    toolVersion = "0.8.10"
-    reportsDirectory = file("$rootProject.projectDir/build/reports/jacoco")
+    toolVersion = "${jacocoVersion}"
+    reportsDirectory = layout.buildDirectory.dir("reports/jacoco")
 }
 
 jacocoTestReport {

--- a/graphql-code-generator/build.gradle
+++ b/graphql-code-generator/build.gradle
@@ -17,7 +17,7 @@
 
 plugins {
     id "java"
-    id "com.github.johnrengelman.shadow"
+    id "com.gradleup.shadow"
     id "checkstyle"
 }
 
@@ -56,13 +56,13 @@ checkstyle {
 checkstyleMain.dependsOn(":checkstyle:downloadCheckstyleRuleFiles")
 checkstyleTest.dependsOn(":checkstyle:downloadCheckstyleRuleFiles")
 
-def bDistribution = file("$project.buildDir/extracted-distribution/jballerina-tools-${ballerinaLangVersion}")
+def bDistribution = layout.buildDirectory.dir("extracted-distribution/jballerina-tools-${ballerinaLangVersion}").get().asFile
 task jBallerinaPack {
     doLast {
         configurations.jbalTools.resolvedConfiguration.resolvedArtifacts.each { artifact ->
             copy {
                 from project.zipTree(artifact.getFile())
-                into new File(project.buildDir, "extracted-distribution/")
+                into layout.buildDirectory.dir("extracted-distribution/").get().asFile
             }
         }
     }
@@ -74,20 +74,20 @@ task unpackStdLibs() {
         configurations.ballerinaStdLibs.resolvedConfiguration.resolvedArtifacts.each { artifact ->
             copy {
                 from project.zipTree(artifact.getFile())
-                into new File("${project.buildDir}/extracted-distribution/" + artifact.name + "-zip")
+                into layout.buildDirectory.dir("extracted-distribution/" + artifact.name + "-zip").get().asFile
             }
         }
     }
 }
 
 task copyStdlibs(type: Copy) {
-    def ballerinaDist = "$project.buildDir/extracted-distribution/jballerina-tools-${ballerinaLangVersion}"
+    def ballerinaDist = layout.buildDirectory.dir("extracted-distribution/jballerina-tools-${ballerinaLangVersion}").get().asFile
     into ballerinaDist
 
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     /* Standard Libraries */
     configurations.ballerinaStdLibs.resolvedConfiguration.resolvedArtifacts.each { artifact ->
-        def artifactExtractedPath = "${project.buildDir}/extracted-distribution/" + artifact.name + "-zip"
+        def artifactExtractedPath = layout.buildDirectory.dir("extracted-distribution/" + artifact.name + "-zip").get().asFile
         into("repo/bala") {
             from "${artifactExtractedPath}/bala/"
         }
@@ -109,8 +109,8 @@ shadowJar {
 }
 
 task copyJar(type: Copy) {
-    from "$project.buildDir/libs/graphql-code-generator-${version}.jar"
-    into "$project.buildDir/extracted-distribution/jballerina-tools-${ballerinaLangVersion}/bre/lib"
+    from layout.buildDirectory.dir("libs").get().asFile.toString() + "/graphql-code-generator-${version}.jar"
+    into layout.buildDirectory.dir("extracted-distribution/jballerina-tools-${ballerinaLangVersion}/bre/lib").get().asFile
 }
 
 compileJava {

--- a/graphql-schema-file-generator/build.gradle
+++ b/graphql-schema-file-generator/build.gradle
@@ -17,7 +17,7 @@
 
 plugins {
     id "java"
-    id "com.github.johnrengelman.shadow"
+    id "com.gradleup.shadow"
     id "checkstyle"
 }
 
@@ -50,13 +50,13 @@ checkstyle {
 checkstyleMain.dependsOn(":checkstyle:downloadCheckstyleRuleFiles")
 checkstyleTest.dependsOn(":checkstyle:downloadCheckstyleRuleFiles")
 
-def bDistribution = file("$project.buildDir/extracted-distribution/jballerina-tools-${ballerinaLangVersion}")
+def bDistribution = layout.buildDirectory.dir("extracted-distribution/jballerina-tools-${ballerinaLangVersion}").get().asFile
 task jBallerinaPack {
     doLast {
         configurations.jbalTools.resolvedConfiguration.resolvedArtifacts.each { artifact ->
             copy {
                 from project.zipTree(artifact.getFile())
-                into new File(project.buildDir, "extracted-distribution/")
+                into layout.buildDirectory.dir("extracted-distribution/").get().asFile
             }
         }
     }
@@ -68,20 +68,20 @@ task unpackStdLibs() {
         configurations.ballerinaStdLibs.resolvedConfiguration.resolvedArtifacts.each { artifact ->
             copy {
                 from project.zipTree(artifact.getFile())
-                into new File("${project.buildDir}/extracted-distribution/" + artifact.name + "-zip")
+                into layout.buildDirectory.dir("extracted-distribution/" + artifact.name + "-zip").get().asFile
             }
         }
     }
 }
 
 task copyStdlibs(type: Copy) {
-    def ballerinaDist = "$project.buildDir/extracted-distribution/jballerina-tools-${ballerinaLangVersion}"
+    def ballerinaDist = layout.buildDirectory.dir("extracted-distribution/jballerina-tools-${ballerinaLangVersion}").get().asFile
     into ballerinaDist
 
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     /* Standard Libraries */
     configurations.ballerinaStdLibs.resolvedConfiguration.resolvedArtifacts.each { artifact ->
-        def artifactExtractedPath = "${project.buildDir}/extracted-distribution/" + artifact.name + "-zip"
+        def artifactExtractedPath = layout.buildDirectory.dir("extracted-distribution/" + artifact.name + "-zip").get().asFile
         into("repo/bala") {
             from "${artifactExtractedPath}/bala/"
         }
@@ -103,8 +103,8 @@ shadowJar {
 }
 
 task copyJar(type: Copy) {
-    from "$project.buildDir/libs/graphql-schema-file-generator-${version}.jar"
-    into "$project.buildDir/extracted-distribution/jballerina-tools-${ballerinaLangVersion}/bre/lib"
+    from layout.buildDirectory.dir("libs").get().asFile.toString() + "/graphql-schema-file-generator-${version}.jar"
+    into layout.buildDirectory.dir("extracted-distribution/jballerina-tools-${ballerinaLangVersion}/bre/lib").get().asFile
 }
 
 compileJava {

--- a/graphql-tool-idl-plugin/build.gradle
+++ b/graphql-tool-idl-plugin/build.gradle
@@ -16,7 +16,7 @@
  */
 
 plugins {
-    id "com.github.johnrengelman.shadow"
+    id "com.gradleup.shadow"
     id "jacoco"
 }
 
@@ -50,13 +50,13 @@ dependencies {
     }
 }
 
-def bDistribution = file("$project.buildDir/extracted-distribution/jballerina-tools-${ballerinaLangVersion}")
+def bDistribution = layout.buildDirectory.dir("extracted-distribution/jballerina-tools-${ballerinaLangVersion}").get().asFile
 task jBallerinaPack {
     doLast {
         configurations.balTools.resolvedConfiguration.resolvedArtifacts.each { artifact ->
             copy {
                 from project.zipTree(artifact.getFile())
-                into new File(project.buildDir, "extracted-distribution/")
+                into layout.buildDirectory.dir("extracted-distribution/").get().asFile
             }
         }
     }
@@ -68,19 +68,19 @@ task unpackStdLibs() {
         configurations.ballerinaStdLibs.resolvedConfiguration.resolvedArtifacts.each { artifact ->
             copy {
                 from project.zipTree(artifact.getFile())
-                into new File("${project.buildDir}/extracted-distribution/" + artifact.name + "-zip")
+                into layout.buildDirectory.dir("extracted-distribution/" + artifact.name + "-zip").get().asFile
             }
         }
     }
 }
 
 task copyStdlibs(type: Copy) {
-    def ballerinaDist = "$project.buildDir/extracted-distribution/jballerina-tools-${ballerinaLangVersion}"
+    def ballerinaDist = layout.buildDirectory.dir("extracted-distribution/jballerina-tools-${ballerinaLangVersion}").get().asFile
     into ballerinaDist
 
     /* Standard Libraries */
     configurations.ballerinaStdLibs.resolvedConfiguration.resolvedArtifacts.each { artifact ->
-        def artifactExtractedPath = "${project.buildDir}/extracted-distribution/" + artifact.name + "-zip"
+        def artifactExtractedPath = layout.buildDirectory.dir("extracted-distribution/" + artifact.name + "-zip").get().asFile
         into("repo/bala") {
             from "${artifactExtractedPath}/bala/"
         }
@@ -102,13 +102,13 @@ shadowJar {
 }
 
 task copyJar(type: Copy) {
-    from "$project.buildDir/libs/graphql-tool-idl-plugin-${version}.jar"
+    from layout.buildDirectory.dir("libs").get().asFile.toString() + "/graphql-tool-idl-plugin-${version}.jar"
     from "$project.rootDir/graphql-cli/build/libs/graphql-cli-${version}.jar"
-    into"$project.buildDir/extracted-distribution/jballerina-tools-${ballerinaLangVersion}/bre/lib"
+    into layout.buildDirectory.dir("extracted-distribution/jballerina-tools-${ballerinaLangVersion}/bre/lib").get().asFile
 }
 
 test {
-    systemProperties = [ "target.dir": "$project.buildDir",
+    systemProperties = [ "target.dir": layout.buildDirectory.get().asFile.toString(),
                          "distributions.dir": bDistribution,
                          "ballerina.home": bDistribution,
                          "ballerina.version": "jballerina-tools-${ballerinaLangVersion}"
@@ -120,8 +120,8 @@ test {
 }
 
 jacoco {
-    toolVersion = "0.8.10"
-    reportsDirectory = file("$rootProject.projectDir/build/reports/jacoco")
+    toolVersion = "${jacocoVersion}"
+    reportsDirectory = layout.buildDirectory.dir("reports/jacoco")
 }
 
 jacocoTestReport {

--- a/graphql-tool/Ballerina.toml
+++ b/graphql-tool/Ballerina.toml
@@ -5,4 +5,4 @@ version = "0.14.0"
 authors = ["Ballerina"]
 keywords = ["graphql", "graphql tool", "gql"]
 license = ["Apache-2.0"]
-distribution = "2201.13.0"
+distribution = "2201.14.0-20260527-050400-74f7e6bf"

--- a/graphql-tool/Ballerina.toml
+++ b/graphql-tool/Ballerina.toml
@@ -5,4 +5,4 @@ version = "0.14.0"
 authors = ["Ballerina"]
 keywords = ["graphql", "graphql tool", "gql"]
 license = ["Apache-2.0"]
-distribution = "2201.14.0-20260527-050400-74f7e6bf"
+distribution = "2201.14.0"

--- a/graphql-tool/build.gradle
+++ b/graphql-tool/build.gradle
@@ -18,6 +18,49 @@
  */
 
 import org.apache.tools.ant.taskdefs.condition.Os
+import org.gradle.process.ExecOperations
+import org.gradle.jvm.toolchain.JavaLanguageVersion
+import org.gradle.jvm.toolchain.JavaToolchainService
+import javax.inject.Inject
+
+abstract class BallerinaExecHelper {
+    @Inject abstract ExecOperations getExecOperations()
+}
+
+abstract class PatchBallerinaScriptsTask extends DefaultTask {
+    @Inject abstract JavaToolchainService getJavaToolchainService()
+
+    @TaskAction
+    void patch() {
+        def launcher = javaToolchainService.launcherFor { spec ->
+            spec.languageVersion.set(JavaLanguageVersion.of(25))
+        }.get()
+        def java25Home = launcher.executablePath.asFile.parentFile.parentFile.absolutePath
+
+        def binDirs = [
+            project.layout.buildDirectory.dir("jballerina-tools-${project.ballerinaLangVersion}/bin").get().asFile,
+            new File("${project.rootDir}/target/ballerina-runtime/bin")
+        ]
+        binDirs.each { binDir ->
+            if (binDir.exists()) {
+                binDir.eachFile { file ->
+                    file.setExecutable(true)
+                    if (!file.name.endsWith('.bat') && !file.name.endsWith('.cmd')) {
+                        def original = file.text
+                        def lines = original.split('\n').toList()
+                        lines = lines.findAll { !it.contains('--sun-misc-unsafe-memory-access=allow') }
+                        def shebangIdx = lines.findIndexOf { it.startsWith('#!') }
+                        if (shebangIdx >= 0) {
+                            lines.add(shebangIdx + 1, "export JAVA_HOME='${java25Home}'")
+                        }
+                        def patched = lines.join('\n') + '\n'
+                        if (patched != original) { file.text = patched }
+                    }
+                }
+            }
+        }
+    }
+}
 
 plugins {
     id 'io.ballerina.plugin'
@@ -75,8 +118,9 @@ task updateTomlFiles {
 }
 
 task commitTomlFiles {
+    def execHelper = project.objects.newInstance(BallerinaExecHelper)
     doLast {
-        project.exec {
+        execHelper.execOperations.exec {
             ignoreExitValue true
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
                 commandLine 'cmd', '/c', "git commit -m \"[Automated] Update the native jar versions\" Ballerina.toml Dependencies.toml BalTool.toml"
@@ -105,7 +149,14 @@ publishing {
     }
 }
 
+task patchBallerinaScripts(type: PatchBallerinaScriptsTask) {
+    dependsOn 'unpackJballerinaTools'
+}
+
 updateTomlFiles.dependsOn copyStdlibs
+copyStdlibs.dependsOn patchBallerinaScripts
+build.dependsOn patchBallerinaScripts
+test.dependsOn patchBallerinaScripts
 build.dependsOn "generatePomFileForMavenPublication"
 build.dependsOn ":graphql-code-generator:build"
 build.dependsOn ":graphql-schema-file-generator:build"

--- a/graphql-tool/build.gradle
+++ b/graphql-tool/build.gradle
@@ -29,6 +29,8 @@ abstract class BallerinaExecHelper {
 
 abstract class PatchBallerinaScriptsTask extends DefaultTask {
     @Inject abstract JavaToolchainService getJavaToolchainService()
+    @Input abstract Property<String> getJballerinaToolsBinPath()
+    @Input abstract Property<String> getBallerinaRuntimeBinPath()
 
     @TaskAction
     void patch() {
@@ -37,20 +39,16 @@ abstract class PatchBallerinaScriptsTask extends DefaultTask {
         }.get()
         def java25Home = launcher.executablePath.asFile.parentFile.parentFile.absolutePath
 
-        def binDirs = [
-            project.layout.buildDirectory.dir("jballerina-tools-${project.ballerinaLangVersion}/bin").get().asFile,
-            new File("${project.rootDir}/target/ballerina-runtime/bin")
-        ]
-        binDirs.each { binDir ->
+        [new File(jballerinaToolsBinPath.get()), new File(ballerinaRuntimeBinPath.get())].each { binDir ->
             if (binDir.exists()) {
                 binDir.eachFile { file ->
                     file.setExecutable(true)
                     if (!file.name.endsWith('.bat') && !file.name.endsWith('.cmd')) {
                         def original = file.text
                         def lines = original.split('\n').toList()
-                        lines = lines.findAll { !it.contains('--sun-misc-unsafe-memory-access=allow') }
+                        lines = lines.collect { it.replace('--sun-misc-unsafe-memory-access=allow', '').trim() }.findAll { !it.isEmpty() }
                         def shebangIdx = lines.findIndexOf { it.startsWith('#!') }
-                        if (shebangIdx >= 0) {
+                        if (shebangIdx >= 0 && !lines.any { it.startsWith('export JAVA_HOME=') }) {
                             lines.add(shebangIdx + 1, "export JAVA_HOME='${java25Home}'")
                         }
                         def patched = lines.join('\n') + '\n'
@@ -151,6 +149,9 @@ publishing {
 
 task patchBallerinaScripts(type: PatchBallerinaScriptsTask) {
     dependsOn 'unpackJballerinaTools'
+    outputs.upToDateWhen { !tasks.named('unpackJballerinaTools').get().didWork }
+    jballerinaToolsBinPath = layout.buildDirectory.dir("jballerina-tools-${project.ballerinaLangVersion}/bin").get().asFile.absolutePath
+    ballerinaRuntimeBinPath = "${rootProject.projectDir.absolutePath}/target/ballerina-runtime/bin"
 }
 
 updateTomlFiles.dependsOn copyStdlibs

--- a/settings.gradle
+++ b/settings.gradle
@@ -25,7 +25,6 @@ pluginManagement {
     }
 
     repositories {
-        mavenLocal()
         gradlePluginPortal()
         maven {
             url = 'https://maven.pkg.github.com/ballerina-platform/*'

--- a/settings.gradle
+++ b/settings.gradle
@@ -18,13 +18,14 @@
 
 pluginManagement {
     plugins {
-        id "com.github.johnrengelman.shadow" version "${shadowJarPluginVersion}"
+        id "com.gradleup.shadow" version "${shadowJarPluginVersion}"
         id "de.undercouch.download" version "${downloadPluginVersion}"
         id "net.researchgate.release" version "${releasePluginVersion}"
         id "io.ballerina.plugin" version "${ballerinaGradlePluginVersion}"
     }
 
     repositories {
+        mavenLocal()
         gradlePluginPortal()
         maven {
             url = 'https://maven.pkg.github.com/ballerina-platform/*'
@@ -37,7 +38,7 @@ pluginManagement {
 }
 
 plugins {
-    id "com.gradle.enterprise" version "3.13.2"
+    id "com.gradle.develocity" version "3.19.2"
 }
 
 rootProject.name = 'graphql-tools'
@@ -48,9 +49,9 @@ include(':graphql-code-generator')
 include(':graphql-tool')
 project(':checkstyle').projectDir = file("config${File.separator}checkstyle")
 
-gradleEnterprise {
+develocity {
     buildScan {
-        termsOfServiceUrl = 'https://gradle.com/terms-of-service'
-        termsOfServiceAgree = 'yes'
+        termsOfUseUrl = 'https://gradle.com/terms-of-service'
+        termsOfUseAgree = 'yes'
     }
 }


### PR DESCRIPTION
## Summary

- **Gradle 9.5.1**: Upgrade wrapper; replace removed `buildDir` API with `layout.buildDirectory`; replace `Project.exec()` with `ExecOperations` injection; migrate from `com.gradle.enterprise` to `com.gradle.develocity`; upgrade `net.researchgate.release` to 3.1.0
- **Java 25**: Add Java 25 toolchain to all subprojects; upgrade Ballerina Gradle plugin to 4.0.0 and `ballerinaLangVersion` to `2201.14.0-20260527-050400-74f7e6bf`; update all `[platform.java21]` TOML sections to `[platform.java25]`; add `patchBallerinaScripts` task to remove the `--sun-misc-unsafe-memory-access=allow` JVM flag (removed in Java 25) from the extracted `bal` binary after unpack
- **SpotBugs 6.5.1**: Upgrade for Java 25 class file support; add exclusions for `THROWS`, `AT`, and `USELESS_STRING` detectors
- **JaCoCo 0.8.13**: Upgrade for Java 25 class file instrumentation support
- **CI workflow**: Update to `actions/setup-java@v4` with Java 25

## Test plan
- [ ] `./gradlew build` passes on CI
- [ ] CI passes on Ubuntu and Windows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Upgrade Gradle to 9.5.1 and Migrate to Java 25

This pull request modernizes the project's build system and runtime environment by upgrading Gradle from 8.11.1 to 9.5.1 and configuring Java 25 as the target toolchain.

### Build System Modernization

- **Gradle Wrapper**: Updated to version 9.5.1
- **Plugin Migrations**:
  - Migrated Shadow plugin from `com.github.johnrengelman.shadow` to `com.gradleup.shadow` (updated to 8.3.5)
  - Transitioned from Gradle Enterprise to Gradle Develocity plugin with updated configuration structure
  - Upgraded release plugin to version 3.1.0
- **API Updates**: Replaced deprecated `buildDir` references with Gradle's `layout.buildDirectory` API throughout all build scripts, ensuring compatibility with current Gradle standards

### Java 25 Compatibility

- **Toolchain Configuration**: Added Java 25 toolchain configuration to all subprojects
- **Ballerina Integration**: Updated Ballerina Gradle plugin to version 4.0.0 and set language version to 2201.14.0-20260527-050400-74f7e6bf
- **Script Patching**: Introduced `patchBallerinaScripts` task to post-process Ballerina scripts by removing Java 21-specific flags and configuring appropriate Java home settings for Java 25 compatibility
- **Test Tooling**: Upgraded JaCoCo to 0.8.13 for proper Java 25 class file instrumentation support and upgraded SpotBugs to version 6.5.1 with detector exclusions

### Project Configuration

- Updated TOML platform sections from Java 21 to Java 25
- Refactored `Project.exec()` calls to use injected `ExecOperations` pattern for improved build consistency
- Updated CI workflows to use Java 25 with actions/setup-java@v4

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ballerina-platform/graphql-tools/pull/320?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->